### PR TITLE
Remove empty image when no logo specified

### DIFF
--- a/src/app/+player/player.component.html
+++ b/src/app/+player/player.component.html
@@ -13,7 +13,7 @@
           <h1 [title]="title">{{title}}</h1>
           <h2 [title]="subtitle">{{subtitle}}</h2>
         </hgroup>
-        <logo id="upper-logo"><img [src]="logoSrc" alt=""></logo>
+        <logo id="upper-logo"><img *ngIf="logoSrc" [src]="logoSrc" alt=""></logo>
       </header>
       <controls>
         <buttons (window:keydown)="handleHotkey($event)">
@@ -45,7 +45,7 @@
             <img src="/images/share.svg" alt="">
           </a>
         </nav>
-        <logo id="lower-logo"><img [src]="logoSrc" alt=""></logo>
+        <logo id="lower-logo"><img *ngIf="logoSrc" [src]="logoSrc" alt=""></logo>
       </controls>
     </section>
   </metadata>

--- a/src/app/+player/player.component.ts
+++ b/src/app/+player/player.component.ts
@@ -50,7 +50,7 @@ export class PlayerComponent implements OnChanges, OnDestroy, OnInit {
   private subscribeUrl: string;
   private subscribeTarget: string;
   private artworkUrl: string;
-  private logoSrc: string = window['ENV'].LOGO_NAME ? `/images/${window['ENV'].LOGO_NAME}-logo.svg` : ""
+  private logoSrc: string;
 
   private routerParams: any;
 
@@ -84,6 +84,8 @@ export class PlayerComponent implements OnChanges, OnDestroy, OnInit {
       this.player.ontimeupdate = () => observer.next(this.player.currentTime);
       return (): void => this.player.ontimeupdate = undefined;
     }).share();
+
+    this.logoSrc = window.ENV.LOGO_NAME ? `/images/${window.ENV.LOGO_NAME}-logo.svg` : '';
   }
 
   ngOnChanges(changes: { [key: string]: SimpleChange }) {


### PR DESCRIPTION
Small fix to remove empty img when no LOGO_NAME specified; separately, placate linter by reorganizing `logoSrc` instantiation. 