### PR TITLE
Fix builder embeddable URL

### DIFF
--- a/src/app/+embed/shared/embed-properties/embed-properties.ts
+++ b/src/app/+embed/shared/embed-properties/embed-properties.ts
@@ -30,7 +30,7 @@ export class EmbedProperties {
   }
 
   get embeddableUrl() {
-    return `https://play.prx.org/e?${this.paramString}`;
+    return `${window.location.origin}/e?${this.paramString}`;
   }
 
   iframeHtml(width: string, height: string) {


### PR DESCRIPTION
Use `window.location.origin` instead of hard-coding `https://play.prx.org` for builder embeddable URL (solves #80) 