### PR TITLE
Split up the Feed/Draper adapters

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,10 +61,15 @@
     "karma-cli": "^1.0.1",
     "karma-jasmine": "^1.0.2",
     "karma-remap-istanbul": "^0.2.1",
+    "karma-spec-reporter": "0.0.26",
     "protractor": "4.0.9",
     "ts-node": "1.2.1",
     "tslint": "3.13.0",
     "typescript": "~2.0.3",
     "webdriver-manager": "10.2.5"
+  },
+  "optionalDependencies": {
+    "karma-chrome-launcher": "^2.0.0",
+    "karma-phantomjs-launcher": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "ng test",
     "pree2e": "webdriver-manager update",
     "e2e": "protractor",
-    "ci": "CODECOV=true ng test --watch=false --browsers=PhantomJS && codecov",
+    "ci": "ng test --watch=false --browsers=PhantomJS",
     "build": "ng build --prod",
     "serve": "node lib/server.js dist"
   },

--- a/src/app/embed/adapters/adapter.properties.ts
+++ b/src/app/embed/adapters/adapter.properties.ts
@@ -1,6 +1,5 @@
 import { Observable } from 'rxjs/Observable';
 
-
 export const PropNames = [
   'audioUrl',
   'title',
@@ -23,28 +22,4 @@ export interface AdapterProperties {
 
 export interface DataAdapter {
   getProperties: (params: Object) => Observable<AdapterProperties>;
-}
-
-export function hasMinimumParams(props): boolean {
-  return true; /*
-  return (props.audioUrl !== undefined) &&
-    (props.title !== undefined) &&
-    (props.subtitle !== undefined) &&
-    (props.subscribeUrl !== undefined) &&
-    (props.artworkUrl !== undefined)
-    */
-}
-
-export function getMergedValues(...data: AdapterProperties[]): AdapterProperties {
-  const mergedResult: AdapterProperties = {};
-  const resultsInReversePriority = data.reverse();
-
-  for (let result of resultsInReversePriority)  {
-    for (let property of PropNames) {
-      if (typeof result[property] !== 'undefined') {
-        mergedResult[property] = result[property];
-      }
-    }
-  }
-  return mergedResult;
 }

--- a/src/app/embed/adapters/draper.adapter.spec.ts
+++ b/src/app/embed/adapters/draper.adapter.spec.ts
@@ -1,0 +1,99 @@
+import { testService, injectHttp } from '../../../testing';
+import { DraperAdapter } from './draper.adapter';
+import { FeedAdapter } from './feed.adapter';
+import { EMBED_FEED_ID_PARAM, EMBED_EPISODE_GUID_PARAM } from '../embed.constants';
+
+describe('DraperAdapter', () => {
+
+  testService(DraperAdapter);
+
+  beforeEach(() => {
+    spyOn(FeedAdapter, 'logError').and.stub();
+  });
+
+  const TEST_DRAPE = `<?xml version="1.0" encoding="UTF-8" ?>
+    <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"
+         xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+         xmlns:feedburner="http://rssnamespace.org/feedburner/ext/1.0"
+         xmlns:rp="https://www.w3id.org/rp/v1">
+      <channel>
+        <title>The Channel Title</title>
+        <itunes:image href="http://channel/image.png"/>
+        <rp:image href="http://channel/rp/image.png"/>
+        <atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="self" href="http://atom/self/link"/>
+        <atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="hub" href="http://pubsubhubbub.appspot.com/"/>
+        <item></item>
+        <item>
+          <guid isPermaLink="false">guid-1</guid>
+          <title>Title #1</title>
+          <itunes:image href="http://item1/image.png"/>
+          <rp:image href="http://item1/rp/image.png"/>
+          <enclosure url="http://item1/enclosure.mp3"/>
+          <feedburner:origEnclosureLink>http://item1/original.mp3</feedburner:origEnclosureLink>
+        </item>
+        <item>
+          <guid isPermaLink="false">guid-2</guid>
+          <title>Title #2</title>
+          <itunes:image href="http://item2/image.png"/>
+          <enclosure url="http://item2/enclosure.mp3"/>
+        </item>
+        <item></item>
+      </channel>
+    </rss>
+  `;
+
+  // helper to sync-get properties
+  const getProperties = (feed, feedId = null, guid = null): any => {
+    let params = {}, props = {};
+    if (feedId) { params[EMBED_FEED_ID_PARAM] = feedId; }
+    if (guid) { params[EMBED_EPISODE_GUID_PARAM] = guid; }
+    feed.getProperties(params).subscribe(result => {
+      Object.keys(result).forEach(k => props[k] = result[k]);
+    });
+    return props;
+  };
+
+  it('only runs when feedId and guid are set', injectHttp((feed: DraperAdapter, mocker) => {
+    mocker(TEST_DRAPE);
+    expect(getProperties(feed, null, null)).toEqual({});
+    expect(getProperties(feed, 'http://some.where/feed.xml', null)).toEqual({});
+    expect(getProperties(feed, null, '1234')).toEqual({});
+    expect(getProperties(feed, 'http://some.where/feed.xml', '1234')).not.toEqual({});
+  }));
+
+  it('parses feeds', injectHttp((feed: DraperAdapter, mocker) => {
+    mocker(TEST_DRAPE);
+    let props = getProperties(feed, 'http://some.where/feed.xml', 'guid-1');
+    expect(props.audioUrl).toEqual('http://item1/original.mp3');
+    expect(props.title).toEqual('Title #1');
+    expect(props.subtitle).toEqual('The Channel Title');
+    expect(props.subscribeUrl).toEqual('http://atom/self/link');
+    expect(props.subscribeTarget).toBeUndefined();
+    expect(props.artworkUrl).toEqual('http://item1/rp/image.png');
+    expect(props.feedArtworkUrl).toEqual('http://channel/rp/image.png');
+  }));
+
+  it('falls back to the itunes:image if no rp:image', injectHttp((feed: DraperAdapter, mocker) => {
+    mocker(TEST_DRAPE);
+    let props = getProperties(feed, 'http://some.where/feed.xml', 'guid-2');
+    expect(props.artworkUrl).toEqual('http://item2/image.png');
+  }));
+
+  it('can not find a guid', injectHttp((feed: DraperAdapter, mocker) => {
+    mocker(TEST_DRAPE);
+    let props = getProperties(feed, 'http://some.where/feed.xml', 'guid-not-found');
+    expect(props.audioUrl).toBeUndefined();
+    expect(props.title).toBeUndefined();
+    expect(props.subtitle).toEqual('The Channel Title');
+    expect(props.subscribeUrl).toEqual('http://atom/self/link');
+    expect(props.subscribeTarget).toBeUndefined();
+    expect(props.artworkUrl).toBeUndefined();
+    expect(props.feedArtworkUrl).toEqual('http://channel/rp/image.png');
+  }));
+
+  it('handles http errors', injectHttp((feed: DraperAdapter, mocker) => {
+    mocker('', 500);
+    expect(getProperties(feed, 'whatev', 'guid')).toEqual({});
+  }));
+
+});

--- a/src/app/embed/adapters/draper.adapter.ts
+++ b/src/app/embed/adapters/draper.adapter.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Http } from '@angular/http';
 import { Observable } from 'rxjs';
 import { EMBED_FEED_ID_PARAM, EMBED_EPISODE_GUID_PARAM } from './../embed.constants';
 import { AdapterProperties } from './adapter.properties';
@@ -6,6 +7,10 @@ import { FeedAdapter } from './feed.adapter';
 
 @Injectable()
 export class DraperAdapter extends FeedAdapter {
+
+  constructor(http: Http) {
+    super(http);
+  }
 
   getProperties(params): Observable<AdapterProperties> {
     let feedId = params[EMBED_FEED_ID_PARAM];

--- a/src/app/embed/adapters/draper.adapter.ts
+++ b/src/app/embed/adapters/draper.adapter.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { EMBED_FEED_ID_PARAM, EMBED_EPISODE_GUID_PARAM } from './../embed.constants';
+import { AdapterProperties } from './adapter.properties';
+import { FeedAdapter } from './feed.adapter';
+
+@Injectable()
+export class DraperAdapter extends FeedAdapter {
+
+  getProperties(params): Observable<AdapterProperties> {
+    let feedId = params[EMBED_FEED_ID_PARAM];
+    let episodeGuid = params[EMBED_EPISODE_GUID_PARAM];
+    if (feedId && episodeGuid) {
+      return this.processFeed(feedId, episodeGuid);
+    } else {
+      return Observable.of({});
+    }
+  }
+
+  processDoc(doc: XMLDocument, props: AdapterProperties = {}): AdapterProperties {
+    props = super.processDoc(doc, props);
+    props.feedArtworkUrl = this.getTagAttributeNS(doc, 'rp', 'image', 'href')
+                        || props.feedArtworkUrl;
+    return props;
+  }
+
+  processEpisode(item: Element, props: AdapterProperties = {}): AdapterProperties {
+    props = super.processEpisode(item, props);
+    props.artworkUrl = this.getTagAttributeNS(item, 'rp', 'image', 'href')
+                    || props.artworkUrl;
+    return props;
+  }
+
+  proxyUrl(feedId: string): string {
+    return `https://draper.radiopublic.com/transform?program_id=${feedId}`;
+  }
+
+}

--- a/src/app/embed/adapters/feed.adapter.spec.ts
+++ b/src/app/embed/adapters/feed.adapter.spec.ts
@@ -6,6 +6,10 @@ describe('FeedAdapter', () => {
 
   testService(FeedAdapter);
 
+  beforeEach(() => {
+    spyOn(FeedAdapter, 'logError').and.stub();
+  });
+
   const TEST_FEED = `<?xml version="1.0" encoding="UTF-8" ?>
     <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"
          xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
@@ -62,10 +66,10 @@ describe('FeedAdapter', () => {
     expect(props.feedArtworkUrl).toEqual('http://channel/image.png');
   }));
 
-  it('falls back to the channel for artworkUrl', injectHttp((feed: FeedAdapter, mocker) => {
+  it('does not fallback to channel artwork at this level', injectHttp((feed: FeedAdapter, mocker) => {
     mocker(TEST_FEED);
     let props = getProperties(feed, 'http://some.where/feed.xml', 'guid-2');
-    expect(props.artworkUrl).toEqual('http://channel/image.png');
+    expect(props.artworkUrl).toBeUndefined();
     expect(props.feedArtworkUrl).toEqual('http://channel/image.png');
   }));
 

--- a/src/app/embed/adapters/feed.adapter.spec.ts
+++ b/src/app/embed/adapters/feed.adapter.spec.ts
@@ -1,0 +1,111 @@
+import { testService, injectHttp } from '../../../testing';
+import { FeedAdapter } from './feed.adapter';
+import { EMBED_FEED_URL_PARAM, EMBED_EPISODE_GUID_PARAM } from '../embed.constants';
+
+describe('FeedAdapter', () => {
+
+  testService(FeedAdapter);
+
+  const TEST_FEED = `<?xml version="1.0" encoding="UTF-8" ?>
+    <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"
+         xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+         xmlns:feedburner="http://rssnamespace.org/feedburner/ext/1.0">
+      <channel>
+        <title>The Channel Title</title>
+        <itunes:image href="http://channel/image.png"/>
+        <atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="self" href="http://atom/self/link"/>
+        <atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="hub" href="http://pubsubhubbub.appspot.com/"/>
+        <item>
+          <guid isPermaLink="false">guid-1</guid>
+          <title>Title #1</title>
+          <itunes:image href="http://item1/image.png"/>
+          <enclosure url="http://item1/enclosure.mp3"/>
+          <feedburner:origEnclosureLink>http://item1/original.mp3</feedburner:origEnclosureLink>
+        </item>
+        <item>
+          <guid isPermaLink="false">guid-2</guid>
+          <title>Title #2</title>
+          <enclosure url="http://item2/enclosure.mp3"/>
+        </item>
+      </channel>
+    </rss>
+  `;
+
+  // helper to sync-get properties
+  const getProperties = (feed, feedUrl = null, guid = null): any => {
+    let params = {}, props = {};
+    if (feedUrl) { params[EMBED_FEED_URL_PARAM] = feedUrl; }
+    if (guid) { params[EMBED_EPISODE_GUID_PARAM] = guid; }
+    feed.getProperties(params).subscribe(result => {
+      Object.keys(result).forEach(k => props[k] = result[k]);
+    });
+    return props;
+  };
+
+  it('only runs when feedUrl and guid are set', injectHttp((feed: FeedAdapter, mocker) => {
+    mocker(TEST_FEED);
+    expect(getProperties(feed, null, null)).toEqual({});
+    expect(getProperties(feed, 'http://some.where/feed.xml', null)).toEqual({});
+    expect(getProperties(feed, null, '1234')).toEqual({});
+    expect(getProperties(feed, 'http://some.where/feed.xml', '1234')).not.toEqual({});
+  }));
+
+  it('parses feeds', injectHttp((feed: FeedAdapter, mocker) => {
+    mocker(TEST_FEED);
+    let props = getProperties(feed, 'http://some.where/feed.xml', 'guid-1');
+    expect(props.audioUrl).toEqual('http://item1/original.mp3');
+    expect(props.title).toEqual('Title #1');
+    expect(props.subtitle).toEqual('The Channel Title');
+    expect(props.subscribeUrl).toEqual('http://atom/self/link');
+    expect(props.subscribeTarget).toBeUndefined();
+    expect(props.artworkUrl).toEqual('http://item1/image.png');
+    expect(props.feedArtworkUrl).toEqual('http://channel/image.png');
+  }));
+
+  it('falls back to the channel for artworkUrl', injectHttp((feed: FeedAdapter, mocker) => {
+    mocker(TEST_FEED);
+    let props = getProperties(feed, 'http://some.where/feed.xml', 'guid-2');
+    expect(props.artworkUrl).toEqual('http://channel/image.png');
+    expect(props.feedArtworkUrl).toEqual('http://channel/image.png');
+  }));
+
+  it('falls back to the enclosure for audioUrl', injectHttp((feed: FeedAdapter, mocker) => {
+    mocker(TEST_FEED);
+    let props = getProperties(feed, 'http://some.where/feed.xml', 'guid-2');
+    expect(props.audioUrl).toEqual('http://item2/enclosure.mp3');
+  }));
+
+  it('can not find a guid', injectHttp((feed: FeedAdapter, mocker) => {
+    mocker(TEST_FEED);
+    let props = getProperties(feed, 'http://some.where/feed.xml', 'guid-not-found');
+    expect(props.audioUrl).toBeUndefined();
+    expect(props.title).toBeUndefined();
+    expect(props.subtitle).toEqual('The Channel Title');
+    expect(props.subscribeUrl).toEqual('http://atom/self/link');
+    expect(props.subscribeTarget).toBeUndefined();
+    expect(props.artworkUrl).toBeUndefined();
+    expect(props.feedArtworkUrl).toEqual('http://channel/image.png');
+  }));
+
+  it('can not find anything at all', injectHttp((feed: FeedAdapter, mocker) => {
+    mocker('');
+    expect(getProperties(feed, 'whatev', 'guid')).toEqual({});
+  }));
+
+  it('handles parser errors', injectHttp((feed: FeedAdapter, mocker) => {
+    mocker('{"some":"json"}');
+    expect(getProperties(feed, 'whatev', 'guid')).toEqual({});
+  }));
+
+  it('handles http errors', injectHttp((feed: FeedAdapter, mocker) => {
+    mocker('', 500);
+    expect(getProperties(feed, 'whatev', 'guid')).toEqual({});
+  }));
+
+  it('configures a proxy url', injectHttp((feed: FeedAdapter, mocker) => {
+    expect(feed.proxyUrl('http://some.where/out/there')).toEqual('/proxy?url=http://some.where/out/there');
+    window['ENV'] = {FEED_PROXY_URL: 'http://google.com/'};
+    expect(feed.proxyUrl('http://some.where/out/there')).toEqual('http://google.com/http://some.where/out/there');
+  }));
+
+});

--- a/src/app/embed/adapters/merge.adapter.spec.ts
+++ b/src/app/embed/adapters/merge.adapter.spec.ts
@@ -1,0 +1,80 @@
+import { testService, injectHttp } from '../../../testing';
+import { Subject } from 'rxjs';
+import { AdapterProperties } from './adapter.properties';
+import { MergeAdapter } from './merge.adapter';
+import { FeedAdapter } from './feed.adapter';
+import { QSDAdapter } from './qsd.adapter';
+
+describe('MergeAdapter', () => {
+
+  let qsd: Subject<AdapterProperties>, feed: Subject<AdapterProperties>;
+  testService(MergeAdapter, [
+    {
+      provide: QSDAdapter,
+      useFactory: () => {
+        return {getProperties: () => qsd = new Subject()};
+      }
+    },
+    {
+      provide: FeedAdapter,
+      useFactory: () => {
+        return {getProperties: () => feed = new Subject()};
+      }
+    }
+  ]);
+
+  it('waits the 1st adapter before using the 2nd', injectHttp((merge: MergeAdapter) => {
+    spyOn(merge, 'hasMinimumParams').and.returnValue(true);
+    let props: AdapterProperties;
+    merge.getProperties({}).subscribe(p => props = p);
+    expect(props).toBeUndefined();
+    feed.next({title: 'feed-title'});
+    expect(props).toBeUndefined();
+    qsd.next({});
+    expect(props).toEqual({title: 'feed-title'});
+  }));
+
+  it('overrides adapters by priority', injectHttp((merge: MergeAdapter) => {
+    spyOn(merge, 'hasMinimumParams').and.returnValue(true);
+    let props: AdapterProperties;
+    merge.getProperties({}).subscribe(p => props = p);
+    feed.next({title: 'feed-title'});
+    qsd.next({title: 'qsd-title'});
+    expect(props).toEqual({title: 'qsd-title'});
+  }));
+
+  it('always uses the latest values', injectHttp((merge: MergeAdapter) => {
+    spyOn(merge, 'hasMinimumParams').and.returnValue(true);
+    let props: AdapterProperties;
+    merge.getProperties({}).subscribe(p => props = p);
+    feed.next({title: 'feed-title-1'});
+    feed.next({title: 'feed-title-2'});
+    qsd.next({});
+    expect(props).toEqual({title: 'feed-title-2'});
+  }));
+
+  describe('with lax required properties', () => {
+
+    let oldRequired;
+    beforeEach(() => {
+      oldRequired = MergeAdapter.REQUIRED;
+      MergeAdapter.REQUIRED = ['title', 'subtitle'];
+    });
+    afterEach(() => MergeAdapter.REQUIRED = oldRequired);
+
+    it('enforces required properties', injectHttp((merge: MergeAdapter) => {
+      MergeAdapter.REQUIRED = ['title', 'subtitle'];
+      let props: AdapterProperties;
+      merge.getProperties({}).subscribe(p => props = p);
+      qsd.next({title: 'qsd-title'});
+      expect(props).toBeUndefined();
+      qsd.next({subtitle: 'qsd-subtitle'});
+      expect(props).toBeUndefined();
+      qsd.next({title: 'qsd-title', subtitle: 'qsd-subtitle'});
+      expect(props.title).toEqual('qsd-title');
+      expect(props.subtitle).toEqual('qsd-subtitle');
+    }));
+
+  });
+
+});

--- a/src/app/embed/adapters/merge.adapter.ts
+++ b/src/app/embed/adapters/merge.adapter.ts
@@ -10,7 +10,7 @@ const NO_EMIT_YET = Symbol();
 @Injectable()
 export class MergeAdapter {
 
-  static REQUIRED = ['audioUrl', 'title', 'subtitle', 'subscribeUrl', 'artworkUrl'];
+  static REQUIRED = ['audioUrl', 'title', 'subtitle', 'subscribeUrl', 'feedArtworkUrl'];
 
   private adapters: DataAdapter[];
 

--- a/src/app/embed/adapters/merge.adapter.ts
+++ b/src/app/embed/adapters/merge.adapter.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { QSDAdapter } from './qsd.adapter';
+import { DraperAdapter } from './draper.adapter';
 import { FeedAdapter } from './feed.adapter';
+import { QSDAdapter } from './qsd.adapter';
 import { AdapterProperties, PropNames, DataAdapter } from './adapter.properties';
 
 const NO_EMIT_YET = Symbol();
@@ -13,8 +14,12 @@ export class MergeAdapter {
 
   private adapters: DataAdapter[];
 
-  constructor(private feedAdapter: FeedAdapter, private qsdAdapter: QSDAdapter) {
-    this.adapters = [qsdAdapter, feedAdapter];
+  constructor(
+    private draperAdapter: DraperAdapter,
+    private feedAdapter: FeedAdapter,
+    private qsdAdapter: QSDAdapter,
+  ) {
+    this.adapters = [qsdAdapter, draperAdapter, feedAdapter];
   }
 
   getProperties(params): Observable<AdapterProperties> {

--- a/src/app/embed/adapters/qsd.adapter.spec.ts
+++ b/src/app/embed/adapters/qsd.adapter.spec.ts
@@ -1,0 +1,60 @@
+import { testService, injectHttp } from '../../../testing';
+import { QSDAdapter } from './qsd.adapter';
+import { EMBED_AUDIO_URL_PARAM, EMBED_TITLE_PARAM, EMBED_SUBTITLE_PARAM,
+  EMBED_SUBSCRIBE_URL_PARAM, EMBED_SUBSCRIBE_TARGET, EMBED_IMAGE_URL_PARAM } from './../embed.constants';
+
+describe('QSDAdapter', () => {
+
+  testService(QSDAdapter);
+
+  const mapParams = {
+    audioUrl:        EMBED_AUDIO_URL_PARAM,
+    title:           EMBED_TITLE_PARAM,
+    subtitle:        EMBED_SUBTITLE_PARAM,
+    subscribeUrl:    EMBED_SUBSCRIBE_URL_PARAM,
+    subscribeTarget: EMBED_SUBSCRIBE_TARGET,
+    artworkUrl:      EMBED_IMAGE_URL_PARAM
+  };
+
+  // helper to sync-get properties
+  const getProperties = (qsd, params = {}): any => {
+    let props = {};
+    Object.keys(params).filter(k => mapParams[k]).forEach(k => {
+      params[mapParams[k]] = params[k];
+      delete params[k];
+    });
+    qsd.getProperties(params).subscribe(result => {
+      Object.keys(result).forEach(k => props[k] = result[k]);
+    });
+    return props;
+  };
+
+  it('only runs when a known param is set', injectHttp((qsd: QSDAdapter) => {
+    expect(getProperties(qsd, {})).toEqual({});
+    expect(getProperties(qsd, {foo: 'bar'})).toEqual({});
+    expect(getProperties(qsd, {title: undefined})).toEqual({});
+    expect(getProperties(qsd, {title: ''})).not.toEqual({});
+  }));
+
+  it('decodes params', injectHttp((qsd: QSDAdapter) => {
+    let props = getProperties(qsd, {
+      audioUrl:        'audio-url',
+      title:           'the title',
+      subtitle:        'the subtitle',
+      subscribeUrl:    'subscribe-url',
+      subscribeTarget: 'subscribe-target',
+      artworkUrl:      'artwork-url',
+      feedArtworkUrl:  'feed-artwork-url',
+      foobar:          'the foobar'
+    });
+    expect(props.audioUrl).toEqual('audio-url');
+    expect(props.title).toEqual('the title');
+    expect(props.subtitle).toEqual('the subtitle');
+    expect(props.subscribeUrl).toEqual('subscribe-url');
+    expect(props.subscribeTarget).toEqual('subscribe-target');
+    expect(props.artworkUrl).toEqual('artwork-url');
+    expect(props.feedArtworkUrl).toBeUndefined();
+    expect(props.foobar).toBeUndefined();
+  }));
+
+});

--- a/src/app/embed/adapters/qsd.adapter.ts
+++ b/src/app/embed/adapters/qsd.adapter.ts
@@ -1,18 +1,20 @@
-import {Injectable} from '@angular/core';
-import { EMBED_AUDIO_URL_PARAM, EMBED_TITLE_PARAM, EMBED_SUBTITLE_PARAM,
-  EMBED_SUBSCRIBE_URL_PARAM, EMBED_SUBSCRIBE_TARGET, EMBED_IMAGE_URL_PARAM } from './../embed.constants';
+import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
+import { EMBED_AUDIO_URL_PARAM, EMBED_TITLE_PARAM, EMBED_SUBTITLE_PARAM,
+  EMBED_SUBSCRIBE_URL_PARAM, EMBED_SUBSCRIBE_TARGET, EMBED_IMAGE_URL_PARAM } from '../embed.constants';
 import { AdapterProperties, DataAdapter } from './adapter.properties';
 
 @Injectable()
 export class QSDAdapter implements DataAdapter {
 
   public getProperties(params: Object): Observable<AdapterProperties> {
-    return Observable.of(this.playerProperties(params));
+    let props = this.playerProperties(params);
+    Object.keys(props).filter(k => props[k] === undefined).forEach(key => delete props[key]);
+    return Observable.of(props);
   }
 
   private playerProperties(params): AdapterProperties {
-    return  {
+    return {
       audioUrl:         params[EMBED_AUDIO_URL_PARAM],
       title:            params[EMBED_TITLE_PARAM],
       subtitle:         params[EMBED_SUBTITLE_PARAM],

--- a/src/app/embed/embed.component.ts
+++ b/src/app/embed/embed.component.ts
@@ -2,13 +2,14 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { MergeAdapter } from './adapters/merge.adapter';
 import { QSDAdapter } from './adapters/qsd.adapter';
+import { DraperAdapter } from './adapters/draper.adapter';
 import { FeedAdapter } from './adapters/feed.adapter';
 import { AdapterProperties } from './adapters/adapter.properties';
 
 @Component({
   selector: 'play-embed',
   styleUrls: ['embed.component.css'],
-  providers: [MergeAdapter, QSDAdapter, FeedAdapter],
+  providers: [MergeAdapter, QSDAdapter, DraperAdapter, FeedAdapter],
   template: `
     <play-share-modal *ngIf="showShareModal" (close)="hideModal()">
     </play-share-modal>
@@ -58,6 +59,9 @@ export class EmbedComponent implements OnInit {
     this.subscribeTarget = ( properties.subscribeTarget || this.subscribeTarget || '_blank');
     this.artworkUrl = ( properties.artworkUrl || this.artworkUrl );
     this.feedArtworkUrl = ( properties.feedArtworkUrl || this.feedArtworkUrl );
+
+    // fallback to feed image
+    this.artworkUrl = this.artworkUrl || this.feedArtworkUrl;
   }
 
 }

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,0 +1,41 @@
+/// <reference path="../../node_modules/@types/jasmine/index.d.ts"/>
+import { Type } from '@angular/core';
+import { TestBed, inject } from '@angular/core/testing';
+import { BaseRequestOptions, HttpModule, Http, Response, ResponseOptions } from '@angular/http';
+import { MockBackend } from '@angular/http/testing';
+export { async, inject } from '@angular/core/testing';
+
+// testbed helper
+export function testService(service: Type<any>) {
+  this._testing = service;
+  beforeEach(function() {
+    TestBed.configureTestingModule({
+      imports: [HttpModule],
+      providers: [
+        service,
+        {
+          provide: Http,
+          deps: [MockBackend, BaseRequestOptions],
+          useFactory: (mockBackend, options) => new Http(mockBackend, options)
+        },
+        MockBackend,
+        BaseRequestOptions
+      ]
+    });
+  });
+};
+
+// http request helper
+interface HttpMocker { (responseBody: string|Object, status?: number): void; }
+interface HttpTestCallback { (thingWeAreTesting: any, mocker: HttpMocker): any; }
+export function injectHttp(testFn: HttpTestCallback) {
+  return inject([this._testing, MockBackend], (testing, mockBackend) => {
+    let mocker = (resp: string|Object, status = 200) => {
+      mockBackend.connections.subscribe(conn => {
+        let body = typeof(resp) === 'string' ? resp : JSON.stringify(resp);
+        conn.mockRespond(new Response(new ResponseOptions({body, status})));
+      });
+    };
+    testFn(testing, mocker);
+  });
+};

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -6,7 +6,7 @@ import { MockBackend } from '@angular/http/testing';
 export { async, inject } from '@angular/core/testing';
 
 // testbed helper
-export function testService(service: Type<any>) {
+export function testService(service: Type<any>, extraProviders: any[] = []) {
   this._testing = service;
   beforeEach(function() {
     TestBed.configureTestingModule({
@@ -19,7 +19,8 @@ export function testService(service: Type<any>) {
           useFactory: (mockBackend, options) => new Http(mockBackend, options)
         },
         MockBackend,
-        BaseRequestOptions
+        BaseRequestOptions,
+        ...extraProviders
       ]
     });
   });


### PR DESCRIPTION
- [x] Make the FeedAdapter work independently (when feedUrl+episodeGuid params are present)
- [x] Add a new DraperAdapter (when feedId+episodeGuid params are present)
- [x] Tests!

Running in dev, you can see a [regular feed here](http://play.prx.dev/e?uf=http%3A%2F%2Ffeeds.99percentinvisible.org%2F99percentinvisible&ge=http%3A%2F%2F99percentinvisible.prx.org%2F%3Fp%3D1266), and a [draper feed here](http://play.prx.dev/e?if=109c4b70-691a-4b50-8517-09be0bb245f6&ge=http%3A%2F%2F99percentinvisible.prx.org%2F%3Fp%3D1266).