### PR TITLE
Default to first <item> in a feed when no guid is provided for {Draper,Feed}Adapter

### DIFF
--- a/src/app/embed/adapters/draper.adapter.spec.ts
+++ b/src/app/embed/adapters/draper.adapter.spec.ts
@@ -53,10 +53,10 @@ describe('DraperAdapter', () => {
     return props;
   };
 
-  it('only runs when feedId and guid are set', injectHttp((feed: DraperAdapter, mocker) => {
+  it('only runs when feedId is set', injectHttp((feed: DraperAdapter, mocker) => {
     mocker(TEST_DRAPE);
     expect(getProperties(feed, null, null)).toEqual({});
-    expect(getProperties(feed, 'http://some.where/feed.xml', null)).toEqual({});
+    expect(getProperties(feed, 'http://some.where/feed.xml', null)).not.toEqual({});
     expect(getProperties(feed, null, '1234')).toEqual({});
     expect(getProperties(feed, 'http://some.where/feed.xml', '1234')).not.toEqual({});
   }));

--- a/src/app/embed/adapters/draper.adapter.ts
+++ b/src/app/embed/adapters/draper.adapter.ts
@@ -15,7 +15,7 @@ export class DraperAdapter extends FeedAdapter {
   getProperties(params): Observable<AdapterProperties> {
     let feedId = params[EMBED_FEED_ID_PARAM];
     let episodeGuid = params[EMBED_EPISODE_GUID_PARAM];
-    if (feedId && episodeGuid) {
+    if (feedId) {
       return this.processFeed(feedId, episodeGuid);
     } else {
       return Observable.of({});

--- a/src/app/embed/adapters/feed.adapter.spec.ts
+++ b/src/app/embed/adapters/feed.adapter.spec.ts
@@ -46,10 +46,10 @@ describe('FeedAdapter', () => {
     return props;
   };
 
-  it('only runs when feedUrl and guid are set', injectHttp((feed: FeedAdapter, mocker) => {
+  it('only runs when feedUrl is set', injectHttp((feed: FeedAdapter, mocker) => {
     mocker(TEST_FEED);
     expect(getProperties(feed, null, null)).toEqual({});
-    expect(getProperties(feed, 'http://some.where/feed.xml', null)).toEqual({});
+    expect(getProperties(feed, 'http://some.where/feed.xml', null)).not.toEqual({});
     expect(getProperties(feed, null, '1234')).toEqual({});
     expect(getProperties(feed, 'http://some.where/feed.xml', '1234')).not.toEqual({});
   }));
@@ -110,6 +110,11 @@ describe('FeedAdapter', () => {
     expect(feed.proxyUrl('http://some.where/out/there')).toEqual('/proxy?url=http://some.where/out/there');
     window['ENV'] = {FEED_PROXY_URL: 'http://google.com/'};
     expect(feed.proxyUrl('http://some.where/out/there')).toEqual('http://google.com/http://some.where/out/there');
+  }));
+
+  it('defaults to the first item', injectHttp((feed: FeedAdapter, mocker) => {
+    mocker(TEST_FEED);
+    expect(getProperties(feed, 'whatev').title).toEqual("Title #1");
   }));
 
 });


### PR DESCRIPTION
When no guid is provided and the `DraperAdapter` or `FeedAdapter` are invoked, they should
return the data as though the guid for the first `<item>` encountered in the feed is provided.

The upshot of this is that it is possible to provide an embed that always points at the latest
episode of a given program, which is pretty handy in a few situations. It's also a reasonably
good default for people who don't care to pick a specific episode and instead want to embed
the "show" itself.