### PR TITLE
Don't read from cookies in the http stack in case the iframe is sandboxed

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,12 +1,17 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { HttpModule } from '@angular/http';
+import { HttpModule, Request, XSRFStrategy } from '@angular/http';
 import { SharedModule } from './shared';
+
 
 import { routing, routingProviders, routingComponents } from './app.routing';
 
 import { AppComponent } from './app.component';
+
+class NullXSRFStrategy implements XSRFStrategy {
+  configureRequest(req: Request): void { }
+}
 
 @NgModule({
   declarations: [
@@ -21,7 +26,8 @@ import { AppComponent } from './app.component';
     routing
   ],
   providers: [
-    routingProviders
+    routingProviders,
+    {provide: XSRFStrategy, useClass: NullXSRFStrategy}
   ],
   bootstrap: [AppComponent]
 })


### PR DESCRIPTION
There's no good reason to worry about XSRF right now, and this causes all XHR
requests to fail in a sandboxed iframe (such as the ones wordpress gives you).

I don't love this right now but I didn't know where to stick the null strategy - any ideas where it would make the most sense?