### PR TITLE
CustomEvent for IE 11 and under

### DIFF
--- a/src/app/shared/dovetail/dovetail-audio-event.ts
+++ b/src/app/shared/dovetail/dovetail-audio-event.ts
@@ -1,6 +1,6 @@
 export class DovetailAudioEvent {
   static build(eventName: string, audio: any, extras?: {}) {
-    let event = new Event(eventName);
+    let event: Event = createEvent(eventName);
     Object.defineProperty(event, 'target', {
       value: audio,
       writable: false
@@ -19,5 +19,15 @@ export class DovetailAudioEvent {
       }
     }
     return event;
+  }
+}
+
+function createEvent(name):Event {
+  try {
+    return new Event(name);
+  } catch (e) {
+    let event:any = document.createEvent('CustomEvent');
+    event.initCustomEvent(name, false, false, undefined);
+    return <Event>event;
   }
 }


### PR DESCRIPTION
IE has an inexplicable method for constructing custom events. It includes
the string literal "CustomEvent".

Enjoy.

Fixes #87 