### PR TITLE
Make draper feeds & eps direct to RP landing pages. Fix display issues.

### DIFF
--- a/src/app/embed/adapters/draper.adapter.ts
+++ b/src/app/embed/adapters/draper.adapter.ts
@@ -22,10 +22,24 @@ export class DraperAdapter extends FeedAdapter {
     }
   }
 
+  processFeed(feedUrl: string, episodeGuid?: string): Observable<AdapterProperties> {
+    return super.processFeed(feedUrl, episodeGuid).map(props => {
+      props.subscribeTarget = "_top";
+      if (episodeGuid) {
+        if (!this.isEncoded(episodeGuid)) {
+          episodeGuid = this.encodeGuid(episodeGuid);
+        }
+        props.subscribeUrl = `${props.subscribeUrl}/ep/${episodeGuid}`;
+      }
+      return props;
+    });
+  }
+
   processDoc(doc: XMLDocument, props: AdapterProperties = {}): AdapterProperties {
     props = super.processDoc(doc, props);
     props.feedArtworkUrl = this.getTagAttributeNS(doc, 'rp', 'image', 'href')
                         || props.feedArtworkUrl;
+    props.subscribeUrl = `https://play.radiopublic.com/${this.getTagTextNS(doc, 'rp', 'program-id')}`;
     return props;
   }
 

--- a/src/app/shared/player/player.component.css
+++ b/src/app/shared/player/player.component.css
@@ -58,7 +58,7 @@ section {
   flex-flow: column nowrap;
   justify-content: space-between;
   margin: 20px 15px 15px 0;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 header {

--- a/src/app/shared/player/player.component.css
+++ b/src/app/shared/player/player.component.css
@@ -57,13 +57,19 @@ section {
   display: flex;
   flex-flow: column nowrap;
   justify-content: space-between;
-  margin: 20px 0 15px 0;
+  margin: 20px 15px 15px 0;
+  overflow-x: hidden;
 }
 
 header {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  overflow-x: hidden;
+}
+
+.titles {
+  overflow-x: hidden;
 }
 
 h1,
@@ -92,7 +98,6 @@ h2 {
 .logo {
   width: 30px;
   height: 30px;
-  margin-right: 15px;
   display: none;
 }
 

--- a/src/app/shared/player/player.component.html
+++ b/src/app/shared/player/player.component.html
@@ -9,7 +9,7 @@
     </div>
     <section>
       <header>
-        <div>
+        <div class="titles">
           <h1 [title]="title">{{title}}</h1>
           <h2 [title]="subtitle">{{subtitle}}</h2>
         </div>

--- a/src/assets/images/pause.svg
+++ b/src/assets/images/pause.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="23" height="25" version="1.1" xml:space="preserve"><path d="M0 0L0 25 8 25 8 0 0 0M15 0L15 25 23 25 23 0 15 0Z" fill="#368AA2"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="23" height="25" version="1.1" xml:space="preserve"><path d="M0 0L0 25 8 25 8 0 0 0M15 0L15 25 23 25 23 0 15 0Z" fill="#FFFFFF"/></svg>


### PR DESCRIPTION
I also changed things to use `_top` when draper is in play. Our embeds are sandboxed and `_blank`
is literally not an option - it will turn the link into a noop, which
is already confusing and irritating users. It's for the best, since these
links were previously directing to RSS feeds, so there's that.