### PR TITLE
Bigger PRX logo

### DIFF
--- a/src/app/shared/player/player.component.css
+++ b/src/app/shared/player/player.component.css
@@ -115,14 +115,14 @@ h2 {
 }
 
 .logo {
-  width: 30px;
+  width: auto;
   height: 30px;
   display: none;
 }
 
 .logo > img {
-  width: 100%;
-  height: auto;
+  width: auto;
+  height: 100%;
 }
 
 .controls {


### PR DESCRIPTION
Just to get this out there... what if we auto the height (rather than the width) of the logo image, resulting in a bigger PRX logo.

![image](https://cloud.githubusercontent.com/assets/1410587/22753459/64db4cee-edf9-11e6-8781-a54d8d37b5c8.png)

![image](https://cloud.githubusercontent.com/assets/1410587/22753466/68724eca-edf9-11e6-9fa8-3802d47d0829.png)

This doesn't impact the current RP logo, since it's already square.