### PR TITLE
No loading player on builder path

### DIFF
--- a/env-example
+++ b/env-example
@@ -2,10 +2,11 @@
 # (2) add your ENV overrides here
 # (3) profit
 
-# prx logo
+# Optional player logo (found at src/app/assets/images/[LOGO_NAME]-logo.svg)
 LOGO_NAME=
-# What url to feed requests to 
+
+# Optional external proxy (defaults to using built-in express server)
 FEED_PROXY_URL=
 
-# What set of data sources should we use for fetching information?
-DATA_SOURCES=
+# Optional google analytics
+GA_KEY=

--- a/lib/server.js
+++ b/lib/server.js
@@ -14,27 +14,15 @@ if (process.argv.length !== 3 || ['dev', 'dist'].indexOf(process.argv[2]) < 0) {
   process.exit(1);
 }
 let isDist = process.argv[2] === 'dist';
+util.buildIndex(isDist); // throw compilation errors right away
 
 let app = express();
 let env = util.readEnv(isDist);
 let port = parseInt(process.env.PORT || 4300);
 app.use(morgan('combined', { skip: req => !util.isIndex(req.path) }));
 
-// index.html
-util.buildIndex(isDist); // throw compilation errors right away
-app.use(function sendIndex(req, res, next) {
-  if (util.isIndex(req.path)) {
-    res.setHeader('Content-Type', 'text/html');
-    util.buildIndex(isDist).then((result) => {
-      res.send(result);
-    });
-  } else {
-    next();
-  }
-});
-
 // proxy feed requests
-app.get('/proxy', (req, res) => {
+app.get('/proxy', function proxyFeed(req, res) {
   let feedUrl = url.parse(decodeURIComponent(req.query.url));
   let requester = (feedUrl.protocol === 'http:' ? http : https);
   let proxyReq = requester.request(feedUrl.href, (proxyRes) => {
@@ -48,6 +36,20 @@ app.get('/proxy', (req, res) => {
     res.end();
   });
   proxyReq.end();
+});
+
+// render embeds with inline player markup, other paths without
+app.get('/e', function sendEmbed(req, res) {
+  res.setHeader('Content-Type', 'text/html');
+  util.buildIndex(isDist, true).then(html => res.send(html));
+});
+app.use(function sendIndex(req, res, next) {
+  if (util.isIndex(req.path)) {
+    res.setHeader('Content-Type', 'text/html');
+    util.buildIndex(isDist).then(html => res.send(html));
+  } else {
+    next();
+  }
 });
 
 // asset serving (static or ng serve'd)

--- a/lib/util.js
+++ b/lib/util.js
@@ -65,17 +65,24 @@ exports.findScripts = (isDist) => {
 /**
  * Compile the index
  */
-let cachedEnv = null, cachedScripts = null, cachedFn = null, cachedCss, cachedInline, cachedMarkup;
-exports.buildIndex = (isDist) => {
-  cachedEnv = (isDist && cachedEnv) ? cachedEnv : exports.readEnv();
-  cachedScripts = (isDist && cachedScripts) ? cachedScripts : exports.findScripts(isDist);
-  cachedCss = (isDist && cachedCss) ? cachedCss : exports.getInlineCss(isDist);
-  cachedInline = (isDist && cachedInline) ? cachedInline : exports.getInlineJs(isDist);
-  cachedFn = (isDist && cachedFn) ? cachedFn : pug.compileFile(`${__dirname}/../src/index.pug`);
-  cachedMarkup = (isDist && cachedMarkup) ? cachedMarkup : exports.getLoadingMarkup(isDist, cachedEnv.LOGO_NAME);
-  return cachedMarkup.then((markup) => {
-    return cachedFn({loadingMarkup: markup, inlineJs: cachedInline, css: cachedCss, env: cachedEnv, scripts: cachedScripts, gaKey: cachedEnv.GA_KEY});
-  });
+exports.buildIndex = (isDist, includeLoadingMarkup = false) => {
+  let tpl = cache('html', isDist, () => pug.compileFile(`${__dirname}/../src/index.pug`));
+  let data = {
+    js:      cache('js',      isDist, () => exports.getInlineJs(isDist)),
+    scripts: cache('scripts', isDist, () => exports.findScripts(isDist)),
+    css:     cache('css',     isDist, () => exports.getInlineCss(isDist)),
+    env:     cache('env',     isDist, () => exports.readEnv())
+  };
+
+  if (includeLoadingMarkup) {
+    let loading = cache('loading', isDist, () => exports.getLoadingMarkup(isDist, data.env.LOGO_NAME));
+    return loading.then(markup => {
+      data.loadingMarkup = markup;
+      return tpl(data);
+    });
+  } else {
+    return Promise.resolve(tpl(data));
+  }
 };
 
 /**
@@ -145,6 +152,15 @@ function inlineLoadingPlayer(cssPath, htmlPath, logoName) {
     scrub($, $('.loadingRender').children(), logoName);
     return `<style>${mediaQueries}</style>${$('.loadingRender').html()}`;
   });
+}
+
+const CACHED = {};
+function cache(key, useCached, cacheFn) {
+  if (useCached && CACHED[key]) {
+    return CACHED[key];
+  } else {
+    return CACHED[key] = cacheFn();
+  }
 }
 
 function scrub($, elems, logoName) {

--- a/src/index.pug
+++ b/src/index.pug
@@ -7,15 +7,15 @@ html(lang='en')
     meta(name='viewport' content='width=device-width, initial-scale=1')
     link(rel='icon' type='image/x-icon' href='/assets/images/favicon.png')
     != css
-    if gaKey
+    if env.GA_KEY
       script.
         window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', '${gaKey}', 'auto');
+        ga('create', '#{env.GA_KEY}', 'auto');
       script(async src='https://www.google-analytics.com/analytics.js')
   body(margin: 0)
     play-root
       != loadingMarkup
-    != inlineJs
+    != js
     script(type='text/javascript')
       != 'window.ENV=' + JSON.stringify(env)
     for script in scripts


### PR DESCRIPTION
Only show the inline-player loading markup on the `/e` path.  Was previously showing it for every path (including the builder).

(Also fixes GA_KEYs).