### PR TITLE
Skip over unplayable audio

### DIFF
--- a/src/app/shared/dovetail/dovetail-arrangement.ts
+++ b/src/app/shared/dovetail/dovetail-arrangement.ts
@@ -4,6 +4,7 @@ export interface DovetailArrangementEntry {
   duration?: number;
   audioUrl?: string;
   impressionUrl: string;
+  unplayable: boolean;
 }
 
 export interface DovetailArrangement {


### PR DESCRIPTION
Firefox has trouble playing back our 0-length tracker ads.

This catches those playback errors, sends the ad-impression, and skips to the next file.