### PR TITLE
Give estimated durations for playlist; add skip button

### DIFF
--- a/src/app/shared/player/player.component.css
+++ b/src/app/shared/player/player.component.css
@@ -244,4 +244,7 @@ play-progress {
   #upper-logo {
     display: block;
   }
+  #skip-button-2 {
+    display: none;
+  }
 }

--- a/src/app/shared/player/player.component.html
+++ b/src/app/shared/player/player.component.html
@@ -30,7 +30,7 @@
             <button (click)="seekBy(30)" id="forward-control-button">
               <img src="/assets/images/forward-30.svg" alt="">
             </button>
-            <button *ngIf="showPlaylist" (click)="skipTrack()" id="skip-button">
+            <button *ngIf="showPlaylist" (click)="skipTrack()" id="skip-button-1">
               <img src="/assets/images/skip.svg" alt="">
             </button>
 
@@ -49,6 +49,9 @@
             <a (click)="showShareModal()" id="share-button">
               <img class="nav-button" src="/assets/images/share.svg" alt="">
             </a>
+            <button id="skip-button-2" *ngIf="showPlaylist" (click)="skipTrack()">
+              <img src="/assets/images/skip.svg" alt="">
+            </button>
           </nav>
           <div class="logo" id="lower-logo"><img *ngIf="logoSrc" [src]="logoSrc" alt=""></div>
         </div>

--- a/src/app/shared/playlist/playlist.component.html
+++ b/src/app/shared/playlist/playlist.component.html
@@ -1,7 +1,7 @@
 <div class="playlist-container">
   <header class="playlist-info">
     <em>{{episodes.length}} episodes</em>
-    <small>{{ totalDuration | duration }}</small>
+    <small>{{ estDuration(totalDuration) }}</small>
   </header>
   <ol>
     <li class="playlist-entry" (click)="playlistItemClicked.emit(episode.index)" *ngFor="let episode of episodes">
@@ -21,7 +21,7 @@
         </div>
       </div>
       <small>
-        {{ episode.duration | duration }}
+        {{ estDuration(episode.duration) }}
       </small>
     </li>
   </ol>

--- a/src/app/shared/playlist/playlist.component.spec.ts
+++ b/src/app/shared/playlist/playlist.component.spec.ts
@@ -58,4 +58,13 @@ describe('PlaylistComponent', () => {
     comp.episodes = [{duration: '27'}, {duration: '31'}];
     expect(comp.totalDuration).toEqual(58);
   });
+
+  it('can estimate durations', () => {
+    // This allows for discrepancy between player-detected duration, which can
+    // vary moment to moment based on what ads are served, and itunes:duration from feed.
+    // TODO: store ad duration with ad in Adzerk and use that to calculate duration instead.
+    expect(comp.estDuration(1643)).toEqual('27m');
+    expect(comp.estDuration(3661)).toEqual('1h 1m');
+    expect(comp.estDuration(4801312)).toEqual('55d 13h 41m');
+  });
 });

--- a/src/app/shared/playlist/playlist.component.ts
+++ b/src/app/shared/playlist/playlist.component.ts
@@ -18,4 +18,15 @@ export class PlaylistComponent {
     return this.episodes.reduce((accum, ep) => accum + +ep.duration, 0);
   }
 
+  estDuration(seconds: number): string {
+    const secPerUnit = { d: 86400, h: 3600, m: 60 };
+    let timeEst = '';
+    Object.keys(secPerUnit).forEach(unit => {
+      if (seconds / secPerUnit[unit] > 1) {
+        timeEst += `${Math.floor(seconds / secPerUnit[unit])}${unit} `;
+        seconds %= secPerUnit[unit];
+      }
+    });
+    return timeEst.trim();
+  }
 }

--- a/src/app/shared/playlist/playlist.component.ts
+++ b/src/app/shared/playlist/playlist.component.ts
@@ -22,7 +22,7 @@ export class PlaylistComponent {
     const secPerUnit = { d: 86400, h: 3600, m: 60 };
     let timeEst = '';
     Object.keys(secPerUnit).forEach(unit => {
-      if (seconds / secPerUnit[unit] > 1) {
+      if (seconds / secPerUnit[unit] >= 1) {
         timeEst += `${Math.floor(seconds / secPerUnit[unit])}${unit} `;
         seconds %= secPerUnit[unit];
       }


### PR DESCRIPTION
- gives a rounded estimate for the playlist episodes and the playlist as a whole, to account for likely discrepancies between the RSS itunes:durations and the actual length of the file that gets delivered (ad file duration being the X factor) 
- adds the skip button to the narrow view of player 