### PR TITLE
Add Max-Age cache-control header to proxy responses

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -23,6 +23,8 @@ app.use(morgan('combined', { skip: req => !util.isIndex(req.path) }));
 
 // proxy feed requests
 app.get('/proxy', function proxyFeed(req, res) {
+  res.setHeader('Max-Age', '30');
+
   let feedUrl = url.parse(decodeURIComponent(req.query.url));
   let requester = (feedUrl.protocol === 'http:' ? http : https);
   let proxyReq = requester.request(feedUrl.href, (proxyRes) => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -23,7 +23,7 @@ app.use(morgan('combined', { skip: req => !util.isIndex(req.path) }));
 
 // proxy feed requests
 app.get('/proxy', function proxyFeed(req, res) {
-  res.setHeader('Max-Age', '30');
+  res.setHeadersetHeader('Cache-Control', 'public, max-age=30');
 
   let feedUrl = url.parse(decodeURIComponent(req.query.url));
   let requester = (feedUrl.protocol === 'http:' ? http : https);


### PR DESCRIPTION
If we're putting play behind a CDN it's probably better to let it respect the origin cache behavior than to just try to define it at the cache. I picked 30s because it seems like that's a pretty reasonable delay for feed changes to be available in the builder or a playlist player. Even a few minutes would probably be okay, but erring on the side of people being impatient.