### PR TITLE
Add max-age for non-proxy paths

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -43,11 +43,13 @@ app.get('/proxy', function proxyFeed(req, res) {
 // render embeds with inline player markup, other paths without
 app.get('/e', function sendEmbed(req, res) {
   res.setHeader('Content-Type', 'text/html');
+  res.setHeader('Cache-Control', 'public, max-age=300');
   util.buildIndex(isDist, true).then(html => res.send(html));
 });
 app.use(function sendIndex(req, res, next) {
   if (util.isIndex(req.path)) {
     res.setHeader('Content-Type', 'text/html');
+    res.setHeader('Cache-Control', 'public, max-age=300');
     util.buildIndex(isDist).then(html => res.send(html));
   } else {
     next();


### PR DESCRIPTION
Adding a 5 minute max-age for `/e` and other paths that aren't `/proxy`