### PR TITLE
Show no-ssl warning in builder; fix CDATA bug

### DIFF
--- a/src/app/builder/builder.component.css
+++ b/src/app/builder/builder.component.css
@@ -120,8 +120,12 @@ label {
   height: 20px;
 }
 
-.builder-step input[type='url'].error {
-  outline: 5px auto #e32
+.error {
+  outline: 5px auto #e32;
+}
+
+.warning {
+  outline: 5px auto #f59f51;
 }
 
 .builder-step button[type='submit'],

--- a/src/app/builder/builder.component.html
+++ b/src/app/builder/builder.component.html
@@ -52,6 +52,7 @@
         <button type="submit">Submit</button>
       </form>
       <p *ngIf="feedError"><em>{{feedUrl}}</em> is not an RSS feed.</p>
+      <p *ngIf="sslError"><em>{{sslError}}</em></p>
     </section>
 
     <section class="builder-step" *ngIf="feedUrl && !feedError" id="step-2">

--- a/src/app/builder/builder.component.html
+++ b/src/app/builder/builder.component.html
@@ -46,7 +46,7 @@
     <section *ngIf="!editMode" class="builder-step" id="step-1">
       <form id="feed-selector" (submit)="onFeedUrlSubmit(feedUrlInput.value)">
         <label for="feedUrl">Select podcast</label>
-        <input [class.error]="this.feedError" type="url" id="feedUrl" required pattern="^http.*"
+        <input [class.warning]="this.sslError" [class.error]="this.feedError" type="url" id="feedUrl" required pattern="^http.*"
           name="feedUrl" [ngModel]="feedUrl" #feedUrlInput
           placeholder="A podcast's RSS feed URL, eg http://example.com/feed.xml">
         <button type="submit">Submit</button>

--- a/src/app/builder/builder.component.html
+++ b/src/app/builder/builder.component.html
@@ -48,7 +48,7 @@
         <label for="feedUrl">Select podcast</label>
         <input [class.warning]="this.sslError" [class.error]="this.feedError" type="url" id="feedUrl" required pattern="^http.*"
           name="feedUrl" [ngModel]="feedUrl" #feedUrlInput
-          placeholder="A podcast's RSS feed URL, eg http://example.com/feed.xml">
+          placeholder="A podcast's RSS feed URL, eg https://example.com/feed.xml">
         <button type="submit">Submit</button>
       </form>
       <p *ngIf="feedError"><em>{{feedUrl}}</em> is not an RSS feed.</p>

--- a/src/app/builder/builder.component.ts
+++ b/src/app/builder/builder.component.ts
@@ -50,6 +50,7 @@ export class BuilderComponent implements OnInit {
     });
     this.builderForm.control.valueChanges.debounceTime(3500).forEach(() => {
       this.resetPreviewIframe();
+      this.checkForSSL();
     });
   }
 
@@ -101,7 +102,6 @@ export class BuilderComponent implements OnInit {
   }
 
   onEpisodeSelect(episode: Episode) {
-    this.checkForSSL(episode);
     this.playLatest = false;
     let playlistEps = this.props && this.props.playlistLength ? this.props.playlistLength : 0;
     this.props = new BuilderProperties(
@@ -126,6 +126,7 @@ export class BuilderComponent implements OnInit {
       epImageUrl: episode.epImageUrl,
       subscribeUrl: this.feedUrl
     };
+    this.checkForSSL();
     this.resetPreviewIframe();
   }
 
@@ -133,20 +134,23 @@ export class BuilderComponent implements OnInit {
     el.innerHTML = 'Copy';
   }
 
-  checkForSSL(ep: Episode) {
+  checkForSSL() {
     this.sslError = null;
-    const urls = {
-      'Audio URL': ep.url,
-      'Feed Image URL': ep.feedImageUrl,
-      'Spotlight Artwork URL': ep.epImageUrl
-    };
-    Object.keys(urls).forEach(field => {
-      if (urls[field].match(/http:\/\//)) {
-        this.sslError = `Play.prx.org supports SSL. In order to comply, the ${field} should be served over HTTPS. ` +
-        `This insecure URL may cause some unpredictable behavior.`
-        return;
-      }
-    })
+    if (this.props || this.defaults) {
+      const urlFields = {
+        audioUrl: 'Audio URL',
+        epImageUrl: 'Spotlight Artwork URL',
+        feedImageUrl: 'Background Artwork URL'
+      };
+      Object.keys(urlFields).forEach(field => {
+        let fieldToCheck = this.props[field] || this.defaults[field];
+        if (fieldToCheck && fieldToCheck.match(/http:\/\//)) {
+          this.sslError = `Play.prx.org supports SSL. In order to comply, the ${urlFields[field]} ` +
+          ` should be served over HTTPS. This insecure URL may cause some unpredictable behavior.`;
+          return;
+        }
+      });
+    }
   }
   // Copies the HTML code in an input associated with the element (<button>)
   // that is passed in

--- a/src/app/builder/builder.component.ts
+++ b/src/app/builder/builder.component.ts
@@ -24,6 +24,7 @@ export class BuilderComponent implements OnInit {
   playLatest = false;
   playPlaylist = false;
   feedError = false;
+  sslError: string = null;
 
   @ViewChild('builderForm') builderForm;
 
@@ -100,6 +101,7 @@ export class BuilderComponent implements OnInit {
   }
 
   onEpisodeSelect(episode: Episode) {
+    this.checkForSSL(episode);
     this.playLatest = false;
     let playlistEps = this.props && this.props.playlistLength ? this.props.playlistLength : 0;
     this.props = new BuilderProperties(
@@ -131,6 +133,21 @@ export class BuilderComponent implements OnInit {
     el.innerHTML = 'Copy';
   }
 
+  checkForSSL(ep: Episode) {
+    this.sslError = null;
+    const urls = {
+      'Audio URL': ep.url,
+      'Feed Image URL': ep.feedImageUrl,
+      'Spotlight Artwork URL': ep.epImageUrl
+    };
+    Object.keys(urls).forEach(field => {
+      if (urls[field].match(/http:\/\//)) {
+        this.sslError = `Play.prx.org supports SSL. In order to comply, the ${field} should be served over HTTPS. ` +
+        `This insecure URL may cause some unpredictable behavior.`
+        return;
+      }
+    })
+  }
   // Copies the HTML code in an input associated with the element (<button>)
   // that is passed in
   copyCode(inp: HTMLInputElement, button: Element) {

--- a/src/app/builder/episode/episode-picker.component.ts
+++ b/src/app/builder/episode/episode-picker.component.ts
@@ -92,7 +92,7 @@ export class EpisodePickerComponent implements OnChanges, OnInit {
 
         let fbOrigEncUrl = item.querySelector('origEnclosureLink');
         if (fbOrigEncUrl) {
-          encUrl = fbOrigEncUrl.innerHTML;
+          encUrl = fbOrigEncUrl.textContent;
         }
 
         let guid = item.querySelector('guid').textContent;

--- a/src/app/builder/episode/episode-picker.component.ts
+++ b/src/app/builder/episode/episode-picker.component.ts
@@ -95,7 +95,7 @@ export class EpisodePickerComponent implements OnChanges, OnInit {
           encUrl = fbOrigEncUrl.innerHTML;
         }
 
-        let guid = item.querySelector('guid').innerHTML;
+        let guid = item.querySelector('guid').textContent;
 
         episodes.push(new Episode(encUrl, guid, title, artist, feedImg, epImg));
       }

--- a/src/app/embed/adapters/feed.adapter.ts
+++ b/src/app/embed/adapters/feed.adapter.ts
@@ -10,6 +10,7 @@ import { AdapterProperties, DataAdapter } from './adapter.properties';
 import { sha1 }  from './sha1';
 
 const GUID_PREFIX = 's1!';
+const CDATA = '<![CDATA[';
 
 @Injectable()
 export class FeedAdapter implements DataAdapter {
@@ -22,7 +23,7 @@ export class FeedAdapter implements DataAdapter {
 
   getProperties(params): Observable<AdapterProperties> {
     let feedUrl = params[EMBED_FEED_URL_PARAM];
-    let episodeGuid = params[EMBED_EPISODE_GUID_PARAM];
+    let episodeGuid = this.removeCDATA(params[EMBED_EPISODE_GUID_PARAM]);
     let numEpisodes;
     if (typeof params[EMBED_SHOW_PLAYLIST_PARAM] !== 'undefined') {
       numEpisodes = params[EMBED_SHOW_PLAYLIST_PARAM] || 10;
@@ -132,6 +133,14 @@ export class FeedAdapter implements DataAdapter {
     } else {
       return `/proxy?url=${feedUrl}`;
     }
+  }
+
+  protected hasCDATA(guid): boolean {
+    return (guid.indexOf(CDATA) > -1);
+  }
+
+  protected removeCDATA(guid): string {
+    return this.hasCDATA(guid) ? guid.replace(CDATA, '').replace(/\]\]\>/, '') : guid;
   }
 
   protected isEncoded(guid): boolean {

--- a/src/app/embed/adapters/feed.adapter.ts
+++ b/src/app/embed/adapters/feed.adapter.ts
@@ -136,7 +136,7 @@ export class FeedAdapter implements DataAdapter {
   }
 
   protected hasCDATA(guid): boolean {
-    return (guid.indexOf(CDATA) > -1);
+    return guid ? (guid.indexOf(CDATA) > -1) : false;
   }
 
   protected removeCDATA(guid): string {


### PR DESCRIPTION
CDATA  (#142): 
-use `textContent` instead of `innerHTML` when selecting an episode from builder to successfully strip out CDATA from `guid` tag
-strip CDATA from guids sent through query params to feed adapter

SSL (#141): show text warning to user on builder if: 
-they select an episode with non-https audio, episode art, or feed art URL
-they override any URL fields to use non-https URL 

Not sure whether to show the text warning if the feed url itself is non-https -- won't that show error to all feedburner URLs? 