### PR TITLE
Get tests running again

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,6 +10,7 @@ module.exports = function (config) {
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
+      require('karma-spec-reporter'),
       require('@angular/cli/plugins/karma')
     ],
     client:{

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,10 +6,11 @@ module.exports = function (config) {
     basePath: '',
     frameworks: ['jasmine', '@angular/cli'],
     plugins: [
-      require('karma-jasmine'),
       require('karma-chrome-launcher'),
-      require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
+      require('karma-jasmine'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-phantomjs-launcher'),
       require('karma-spec-reporter'),
       require('@angular/cli/plugins/karma')
     ],

--- a/src/app/embed/adapters/draper.adapter.spec.ts
+++ b/src/app/embed/adapters/draper.adapter.spec.ts
@@ -20,6 +20,7 @@ describe('DraperAdapter', () => {
         <title>The Channel Title</title>
         <itunes:image href="http://channel/image.png"/>
         <rp:image href="http://channel/rp/image.png"/>
+        <rp:program-id>foo</rp:program-id>
         <atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="self" href="http://atom/self/link"/>
         <atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="hub" href="http://pubsubhubbub.appspot.com/"/>
         <item></item>
@@ -67,8 +68,8 @@ describe('DraperAdapter', () => {
     expect(props.audioUrl).toEqual('http://item1/original.mp3');
     expect(props.title).toEqual('Title #1');
     expect(props.subtitle).toEqual('The Channel Title');
-    expect(props.subscribeUrl).toEqual('http://atom/self/link');
-    expect(props.subscribeTarget).toBeUndefined();
+    expect(props.subscribeUrl).toEqual('https://play.radiopublic.com/foo/ep/s1!e661165c969fa6801bb8a7711daa73544b5149e9');
+    expect(props.subscribeTarget).toEqual('_top');
     expect(props.artworkUrl).toEqual('http://item1/rp/image.png');
     expect(props.feedArtworkUrl).toEqual('http://channel/rp/image.png');
   }));
@@ -85,8 +86,8 @@ describe('DraperAdapter', () => {
     expect(props.audioUrl).toBeUndefined();
     expect(props.title).toBeUndefined();
     expect(props.subtitle).toEqual('The Channel Title');
-    expect(props.subscribeUrl).toEqual('http://atom/self/link');
-    expect(props.subscribeTarget).toBeUndefined();
+    expect(props.subscribeUrl).toEqual('https://play.radiopublic.com/foo/ep/s1!f0ac9c9a4b7ad98f1663f828eb6b5587dfce3434');
+    expect(props.subscribeTarget).toEqual('_top');
     expect(props.artworkUrl).toBeUndefined();
     expect(props.feedArtworkUrl).toEqual('http://channel/rp/image.png');
   }));

--- a/src/app/embed/adapters/draper.adapter.ts
+++ b/src/app/embed/adapters/draper.adapter.ts
@@ -24,12 +24,16 @@ export class DraperAdapter extends FeedAdapter {
 
   processFeed(feedUrl: string, episodeGuid?: string): Observable<AdapterProperties> {
     return super.processFeed(feedUrl, episodeGuid).map(props => {
-      props.subscribeTarget = '_top';
+      if (Object.keys(props).length) {
+        props.subscribeTarget = '_top';
+      }
       if (episodeGuid) {
         if (!this.isEncoded(episodeGuid)) {
           episodeGuid = this.encodeGuid(episodeGuid);
         }
-        props.subscribeUrl = `${props.subscribeUrl}/ep/${episodeGuid}`;
+        if (props.subscribeUrl && !/\/ep\//.test(props.subscribeUrl)) {
+          props.subscribeUrl = `${props.subscribeUrl}/ep/${episodeGuid}`;
+        }
       }
       return props;
     });

--- a/src/app/embed/adapters/feed.adapter.ts
+++ b/src/app/embed/adapters/feed.adapter.ts
@@ -148,7 +148,7 @@ export class FeedAdapter implements DataAdapter {
   }
 
   protected encodeGuid(guid): string {
-    return `${GUID_PREFIX}${sha1.hash(guid)};`;
+    return `${GUID_PREFIX}${sha1.hash(guid)}`;
   }
 
   protected getTagText(el: Element | XMLDocument, tag: string): string {

--- a/src/app/shared/audio/extendable-audio.ts
+++ b/src/app/shared/audio/extendable-audio.ts
@@ -17,7 +17,15 @@ export class ExtendableAudio {
   volume: number;
 
   constructor(url) {
-    this._audio = new Audio();
+    if (typeof window['Audio'] !== 'undefined') {
+      this._audio = new Audio();
+    } else {
+      // Basically make audio a noop on phantom or browsers with no Audio support
+      this._audio = ({addEventListener: noop} as any) as HTMLAudioElement;
+      // TODO: maybe we should detect this and throw up a warning for those
+      // people on ie6?
+    }
+
     // This is our proxy for DOM events
     this._documentFragment = document.createDocumentFragment();
     this._toSetUrl = url;
@@ -58,3 +66,5 @@ export class ExtendableAudio {
   }
 
 }
+
+function noop() { }


### PR DESCRIPTION
Now at least they run again, though many more fail on `npm run ci` than I've seen in a while! 