### PR TITLE
Add HSTS response header

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -44,12 +44,14 @@ app.get('/proxy', function proxyFeed(req, res) {
 app.get('/e', function sendEmbed(req, res) {
   res.setHeader('Content-Type', 'text/html');
   res.setHeader('Cache-Control', 'public, max-age=300');
+  res.setHeader('Strict-Transport-Security', 'max-age=43200');
   util.buildIndex(isDist, true).then(html => res.send(html));
 });
 app.use(function sendIndex(req, res, next) {
   if (util.isIndex(req.path)) {
     res.setHeader('Content-Type', 'text/html');
     res.setHeader('Cache-Control', 'public, max-age=300');
+    res.setHeader('Strict-Transport-Security', 'max-age=43200');
     util.buildIndex(isDist).then(html => res.send(html));
   } else {
     next();


### PR DESCRIPTION
Since we’re redirecting all insecure requests anyway, enforcing this at
the client seems like it’s not a bad idea