### PR TITLE
Add basic infrastructure for generic overlays on player

### DIFF
--- a/src/app/embed/embed.component.css
+++ b/src/app/embed/embed.component.css
@@ -1,7 +1,7 @@
 play-player {
   position: absolute;
   width: 100%;
-  height: 185px;
+  height: 100%;
   display: flex;
   flex-direction: column;
   box-sizing: border-box;

--- a/src/app/embed/embed.component.css
+++ b/src/app/embed/embed.component.css
@@ -2,6 +2,7 @@ play-player {
   position: absolute;
   width: 100%;
   height: 100%;
+  max-height: 200px;
   display: flex;
   flex-direction: column;
   box-sizing: border-box;

--- a/src/app/shared/player/player.component.css
+++ b/src/app/shared/player/player.component.css
@@ -28,7 +28,7 @@
   opacity: 0;
   transform: scale(2.0);
   pointer-events: none;
-  transition: top var(--overlay-animation-duration), opacity var(--overlay-animation-duration), transform var(--overlay-animation-duration);
+  transition: top 0.2s, opacity 0.2s, transform 0.2s;
 }
 
 .overlayed .overlayContent {
@@ -39,8 +39,6 @@
 }
 
 content {
-  --overlay-animation-duration: 0.2s;
-  --artwork-size: 117px;
   font-family: "Source Sans Pro";
   background: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.3));
   position: fixed;
@@ -55,43 +53,15 @@ content {
   flex-flow: column nowrap;
 }
 
-@media (max-height: 174px) {
-  content {
-    --artwork-size: 100px;
-  }
-}
-
-@media (max-height: 160px) {
-  content {
-    --artwork-size: 90px;
-  }
-}
-
-@media (min-height: 185px) {
-  content {
-    --artwork-size: 125px;
-  }
-}
-
-@media (min-height: 195px) {
-  content {
-    --artwork-size: 135px;
-  }
-}
-
 .metadata {
-  flex: calc(var(--artwork-size) + 30px) 0 0;
+  flex: 0 0 calc(117px + 30px);
   display: flex;
   position: relative;
 }
 
-section {
-  flex-grow: 1;
-}
-
 .artwork {
-  width: var(--artwork-size);
-  height: var(--artwork-size);
+  width: 117px;
+  height: 117px;
   box-sizing: border-box;
   position: relative;
   margin: 15px;
@@ -99,7 +69,53 @@ section {
   border: solid 1px #ffffff;
   background-color: white;
   align-self: flex-start;
-  transition: width var(--overlay-animation-duration), height var(--overlay-animation-duration);
+  transition: width 0.2s, height 0.2s;
+}
+
+/* size the artwork appropriately according to the screen size */
+
+@media (max-height: 174px) {
+  .artwork {
+    width: 100px;
+    height: 100px;
+  }
+  .metadata {
+    flex: 0 0 calc(100px + 30px);
+  }
+}
+
+@media (max-height: 160px) {
+  .artwork {
+    width: 90px;
+    height: 90px;
+  }
+  .metadata {
+    flex: 0 0 calc(90px + 30px);
+  }
+}
+
+@media (min-height: 185px) {
+  .artwork {
+    width: 125px;
+    height: 125px;
+  }
+  .metadata {
+    flex: 0 0 calc(125px + 30px);
+  }
+}
+
+@media (min-height: 195px) {
+  .artwork {
+    width: 135px;
+    height: 135px;
+  }
+  .metadata {
+    flex: 0 0 calc(135px + 30px);
+  }
+}
+
+section {
+  flex-grow: 1;
 }
 
 .overlayed .artwork {
@@ -126,7 +142,7 @@ section {
   margin: auto !important;
   position: absolute;
   width: 60px; height: 60px;
-  transition: width var(--overlay-animation-duration), height var(--overlay-animation-duration), opacity var(--overlay-animation-duration);
+  transition: width 0.2s, height 0.2s, opacity 0.2s;
   top: 0; left: 0; bottom: 0; right: 0;
   pointer-events: none;
   opacity: 0;
@@ -205,7 +221,7 @@ h2 {
   position: absolute;
   right: 10px;
   top: 100%;
-  transition: top var(--overlay-animation-duration);
+  transition: top 0.2s;
   margin-top: -40px;
 }
 
@@ -218,11 +234,11 @@ h2 {
   opacity: 1;
   position: relative;
   top: 0;
-  transition: opacity var(--overlay-animation-duration), top var(--overlay-animation-duration);
+  transition: opacity 0.2s, top 0.2s;
 }
 
 .buttons button {
-  transition:  width var(--overlay-animation-duration), height var(--overlay-animation-duration);
+  transition:  width 0.2s, height 0.2s;
 }
 
 .overlayed .buttons {
@@ -260,7 +276,7 @@ nav {
   opacity: 1;
   position: relative;
   top: 0;
-  transition: opacity var(--overlay-animation-duration), top var(--overlay-animation-duration);
+  transition: opacity 0.2s, top 0.2s;
 }
 
 .overlayed nav {
@@ -286,7 +302,7 @@ nav a:hover {
   border: 1.5px solid gray;
   background: inherit;
   margin-bottom: 2px; /* This is a bit of a hack to fix border clipping */
-  transition: width var(--overlay-animation-duration), height var(--overlay-animation-duration);
+  transition: width 0.2s, height 0.2s;
 }
 
 .overlayed .nav-button {
@@ -303,7 +319,7 @@ nav a:hover {
   opacity: 1;
   position: relative;
   top: 0;
-  transition: opacity var(--overlay-animation-duration), top var(--overlay-animation-duration);
+  transition: opacity 0.2s, top 0.2s;
 }
 
 .overlayed .scrubber {
@@ -331,7 +347,7 @@ play-progress {
   line-height: 1.5;
   color: #ffffff;
   opacity: 0;
-  transition: opacity var(--overlay-animation-duration);
+  transition: opacity 0.2s;
 }
 
 .playback-progress.loaded, .duration.loaded {

--- a/src/app/shared/player/player.component.css
+++ b/src/app/shared/player/player.component.css
@@ -20,7 +20,27 @@
   background-position: center center;
 }
 
+.overlayContent {
+  position: absolute;
+  color: white;
+  margin-left: 16px;
+  top: 125px;
+  opacity: 0;
+  transform: scale(2.0);
+  pointer-events: none;
+  transition: top var(--overlay-animation-duration), opacity var(--overlay-animation-duration), transform var(--overlay-animation-duration);
+}
+
+.overlayed .overlayContent {
+  opacity: 1;
+  top: 65px;
+  transform: scale(1.0);
+  pointer-events: all;
+}
+
 content {
+  --overlay-animation-duration: 0.2s;
+  --artwork-size: 117px;
   font-family: "Source Sans Pro";
   background: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.3));
   position: fixed;
@@ -62,9 +82,9 @@ content {
 .metadata {
   flex: calc(var(--artwork-size) + 30px) 0 0;
   display: flex;
+  position: relative;
 }
 
-.artwork,
 section {
   flex-grow: 1;
 }
@@ -78,6 +98,14 @@ section {
   border-radius: 5px;
   border: solid 1px #ffffff;
   background-color: white;
+  align-self: flex-start;
+  transition: width var(--overlay-animation-duration), height var(--overlay-animation-duration);
+}
+
+.overlayed .artwork {
+  flex: auto 0 0;
+  width: 52px;
+  height: 52px;
 }
 
 .artwork .artworkBackground {
@@ -95,10 +123,24 @@ section {
 }
 
 #large-playback-control-button {
+  margin: auto !important;
   position: absolute;
-  top: calc(50% - 30px);
-  left: calc(50% - 30px);
-  display: none;
+  width: 60px; height: 60px;
+  transition: width var(--overlay-animation-duration), height var(--overlay-animation-duration), opacity var(--overlay-animation-duration);
+  top: 0; left: 0; bottom: 0; right: 0;
+  pointer-events: none;
+  opacity: 0;
+  cursor: pointer;
+}
+
+#large-playback-control-button img {
+  width: 100%;
+  height: auto;
+}
+
+.overlayed #large-playback-control-button {
+  width: 40px;
+  height: 40px;
 }
 
 section {
@@ -106,7 +148,6 @@ section {
   flex-flow: column nowrap;
   justify-content: space-between;
   margin: 20px 15px 15px 0;
-  overflow: hidden;
 }
 
 header {
@@ -160,18 +201,53 @@ h2 {
   max-height: 30px;
 }
 
+#lower-logo {
+  position: absolute;
+  right: 10px;
+  top: 100%;
+  transition: top var(--overlay-animation-duration);
+  margin-top: -40px;
+}
+
+.overlayed #lower-logo {
+  top: 55px;
+}
+
 .buttons {
   display: flex;
+  opacity: 1;
+  position: relative;
+  top: 0;
+  transition: opacity var(--overlay-animation-duration), top var(--overlay-animation-duration);
+}
+
+.buttons button {
+  transition:  width var(--overlay-animation-duration), height var(--overlay-animation-duration);
+}
+
+.overlayed .buttons {
+  top: -50px;
+  opacity: 0;
+}
+
+.overlayed .buttons button {
+  width: 0; height: 0;
 }
 
 button {
-  min-width: 30px;
+  width: 30px;
+  height: 30px;
   margin-right: 15px;
   border: 0;
   padding: 0;
   background: none;
   cursor: pointer;
   justify-content: center;
+}
+
+button img {
+  height: 100%;
+  width: auto;
 }
 
 button:focus {
@@ -181,6 +257,15 @@ button:focus {
 nav {
   display: flex;
   align-items: center;
+  opacity: 1;
+  position: relative;
+  top: 0;
+  transition: opacity var(--overlay-animation-duration), top var(--overlay-animation-duration);
+}
+
+.overlayed nav {
+  opacity: 0;
+  top: -50px;
 }
 
 nav a {
@@ -201,12 +286,31 @@ nav a:hover {
   border: 1.5px solid gray;
   background: inherit;
   margin-bottom: 2px; /* This is a bit of a hack to fix border clipping */
+  transition: width var(--overlay-animation-duration), height var(--overlay-animation-duration);
+}
+
+.overlayed .nav-button {
+  width: 0;
+  height: 0;
 }
 
 .scrubber {
   display: flex;
   justify-content: space-around;
+  flex: auto 0 0;
+  margin-bottom: 14px;
+  margin-top: 0px;
+  opacity: 1;
+  position: relative;
+  top: 0;
+  transition: opacity var(--overlay-animation-duration), top var(--overlay-animation-duration);
 }
+
+.overlayed .scrubber {
+  opacity: 0;
+  top: 20px;
+}
+
 
 play-progress {
   cursor: col-resize;
@@ -216,7 +320,7 @@ play-progress {
   border-radius: 100px;
   background-color: #ffffff;
   display: block;
-  margin: 6px 0;
+  margin-top: 6px;
   position: relative;
 }
 
@@ -227,7 +331,7 @@ play-progress {
   line-height: 1.5;
   color: #ffffff;
   opacity: 0;
-  transition: opacity 0.5s;
+  transition: opacity var(--overlay-animation-duration);
 }
 
 .playback-progress.loaded, .duration.loaded {
@@ -263,7 +367,10 @@ play-progress {
     display: none;
   }
 
-  #large-playback-control-button,
+  #large-playback-control-button {
+    opacity: 1;
+    pointer-events: all;
+  }
   #lower-logo
   {
     display: block;
@@ -276,5 +383,9 @@ play-progress {
   }
   #skip-button-2 {
     display: none;
+  }
+  .overlayed #large-playback-control-button {
+    opacity: 1;
+    pointer-events: all;
   }
 }

--- a/src/app/shared/player/player.component.css
+++ b/src/app/shared/player/player.component.css
@@ -51,6 +51,7 @@ content {
   box-sizing: border-box;
   display: flex;
   flex-flow: column nowrap;
+  max-height: 200px;
 }
 
 .metadata {

--- a/src/app/shared/player/player.component.css
+++ b/src/app/shared/player/player.component.css
@@ -1,5 +1,9 @@
 @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro');
 
+.player-container {
+  height: 100%;
+}
+
 .background-img {
   filter: blur(25px);
   -webkit-filter: blur(25px);
@@ -7,10 +11,10 @@
   -o-filter: blur(25px);
   margin: -25px;
   /* to account for the white-edge blurring from the filter: blur */
-  min-height: 233px;
+  min-height: calc(100% + 50px);
   width: calc(100% + 50px);
   /* 183px of content (sans border) + 50 to account for the -25px margins */
-  background-size: 100% auto;
+  background-size: cover;
   position: relative;
   z-index: -1;
   background-position: center center;
@@ -27,10 +31,36 @@ content {
   border-radius: 5px;
   border: 1px solid #e6e6e6;
   box-sizing: border-box;
-  height: 185px;
+  display: flex;
+  flex-flow: column nowrap;
+}
+
+@media (max-height: 174px) {
+  content {
+    --artwork-size: 100px;
+  }
+}
+
+@media (max-height: 160px) {
+  content {
+    --artwork-size: 90px;
+  }
+}
+
+@media (min-height: 185px) {
+  content {
+    --artwork-size: 125px;
+  }
+}
+
+@media (min-height: 195px) {
+  content {
+    --artwork-size: 135px;
+  }
 }
 
 .metadata {
+  flex: calc(var(--artwork-size) + 30px) 0 0;
   display: flex;
 }
 
@@ -40,11 +70,10 @@ section {
 }
 
 .artwork {
+  width: var(--artwork-size);
+  height: var(--artwork-size);
+  box-sizing: border-box;
   position: relative;
-  max-width: 115px;
-  width: 115px;
-  min-width: 115px;
-  height: 115px;
   margin: 15px;
   border-radius: 5px;
   border: solid 1px #ffffff;

--- a/src/app/shared/player/player.component.html
+++ b/src/app/shared/player/player.component.html
@@ -1,4 +1,4 @@
-<div class="player-container">
+<div class="player-container" [class.overlayed]="overlayEnabled">
   <div class="background-img" [style.background-image]="feedArtworkSafe"></div>
   <content>
     <div class="metadata">
@@ -68,6 +68,8 @@
       </play-progress>
       <span class="duration" [class.loaded]="duration | async ">{{duration | async | duration}}</span>
     </div>
+
+    <div class="overlayContent">{{overlayText}}</div>
   </content>
   <play-playlist
     *ngIf="showPlaylist && episodes && episodes.length"

--- a/src/app/shared/player/player.component.ts
+++ b/src/app/shared/player/player.component.ts
@@ -33,6 +33,9 @@ export class PlayerComponent implements OnInit, OnChanges {
   feedArtworkSafe: SafeStyle;
   artworkSafeLoaded: SafeStyle;
 
+  overlayEnabled = false;
+  overlayText = "";
+
   // for playlist feature
   episodeIndex = 0;
   player: DovetailAudio;

--- a/src/app/shared/playlist/playlist.component.css
+++ b/src/app/shared/playlist/playlist.component.css
@@ -11,9 +11,9 @@ header, div, h2, em, small, ol, li, img {
 }
 
 .playlist-container {
-  top: 185px;
+  top: 200px;
   position: fixed;
-  height: calc(100% - 185px);
+  height: calc(100% - 200px);
   width: 100%;
   background: white;
   overflow: scroll;


### PR DESCRIPTION
includes some minor vertical responsiveness
![responsive](https://user-images.githubusercontent.com/61664/28639229-7ff91ee8-7215-11e7-972c-c9cb91a554f8.gif)

as well as infrastructure to allow us to support ad takeovers, endslate, and a redesigned share overlay, for both the large version:
![largeoverlay](https://user-images.githubusercontent.com/61664/28639258-955b9ebe-7215-11e7-9838-7fd491b825e8.gif)

and small version of the player:
![smalloverlay](https://user-images.githubusercontent.com/61664/28639267-99b7836a-7215-11e7-8a09-e1ffaa67f3d9.gif)

