### PR TITLE
Alter builder copyable "Square" option

### DIFF
--- a/src/app/builder/builder.component.html
+++ b/src/app/builder/builder.component.html
@@ -7,17 +7,8 @@
   *ngIf="props">Preview</a>
 
 <div id="preview-overlay" #previewOverlay style="display: none;">
-  <!-- <iframe
-    #previewHorizontal
-    *ngIf="previewIframeSrc"
-    frameborder="0"
-    height="200"
-    id="preview-horizontal"
-    width="95%"
-    [src]="previewIframeSrc"></iframe> -->
   <div *ngIf="!playPlaylist" id="preview-horizontal-wrap">
     <iframe
-      #previewSquare
       *ngIf="previewIframeSrc"
       frameborder="0"
       height="185"
@@ -27,7 +18,6 @@
   </div>
   <div *ngIf="playPlaylist" id="preview-playlist-wrap">
     <iframe
-      #previewPlaylist
       *ngIf="previewIframeSrc"
       frameborder="0"
       height="650"
@@ -231,7 +221,7 @@
       <fieldset>
         <label for="embed-code-raw">Embed player URL</label>
         <input type="text" readonly [ngModel]="props.embeddableUrl"
-          id="embed-code-raw" name="embedcoderaw" #codeInputRaw>
+          id="embed-code-raw" #codeInputRaw>
         <button class="copy-code"
           (mouseover)="resetCopyButton(copyBtnRaw)"
           (click)="copyCode(codeInputRaw, copyBtnRaw)"

--- a/src/app/builder/builder.component.html
+++ b/src/app/builder/builder.component.html
@@ -196,9 +196,9 @@
 
       <section *ngIf="!playPlaylist">
         <fieldset>
-          <label for="embed-code-horizontal">Horizontal Episode Player</label>
+          <label for="embed-code-horizontal">Flexible Width Episode Player</label>
           <input type="text" readonly [ngModel]="props.horizontalIframeHtml"
-            id="embed-code-horizontal" name="embedcodehorizontal" #codeInputHorizontal>
+            id="embed-code-horizontal" #codeInputHorizontal>
           <button class="copy-code"
             (mouseover)="resetCopyButton(copyBtnHorizontal)"
             (click)="copyCode(codeInputHorizontal, copyBtnHorizontal)"
@@ -209,15 +209,15 @@
         </fieldset>
 
         <fieldset>
-          <label for="embed-code-square">Square Episode Player</label>
-          <input type="text" readonly [ngModel]="props.squareIframeHtml"
-            id="embed-code-square" name="embedcodesquare" #codeInputSquare>
+          <label for="embed-code-fixed-width">Fixed Width Episode Player</label>
+          <input type="text" readonly [ngModel]="props.fixedWidthIframeHtml"
+            id="embed-code-fixed-width" #codeInputFixedWidth>
           <button class="copy-code"
-            (mouseover)="resetCopyButton(copyBtnSquare)"
-            (click)="copyCode(codeInputSquare, copyBtnSquare)"
-            #copyBtnSquare>Copy</button>
+            (mouseover)="resetCopyButton(copyBtnFixedWidth)"
+            (click)="copyCode(codeInputFixedWidth, copyBtnFixedWidth)"
+            #copyBtnFixedWidth>Copy</button>
           <p>
-            <small>This player is 500 by 500 pixels and displays the artwork in large, prominent format.</small>
+            <small>This player is 200px tall and 500px wide.</small>
           </p>
         </fieldset>
       </section>

--- a/src/app/builder/builder.component.html
+++ b/src/app/builder/builder.component.html
@@ -207,7 +207,7 @@
             (click)="copyCode(codeInputFixedWidth, copyBtnFixedWidth)"
             #copyBtnFixedWidth>Copy</button>
           <p>
-            <small>This player is 200px tall and 500px wide.</small>
+            <small>This player is 200 pixels tall and 500 pixels wide.</small>
           </p>
         </fieldset>
       </section>

--- a/src/app/builder/builder.properties.ts
+++ b/src/app/builder/builder.properties.ts
@@ -79,8 +79,8 @@ export class BuilderProperties {
     return `<iframe frameborder="0" height="${height}" width="${width}" src="${url}"></iframe>`;
   }
 
-  get squareIframeHtml() {
-    return this.iframeHtml('500', '500');
+  get fixedWidthIframeHtml() {
+    return this.iframeHtml('500', '200');
   }
 
   get horizontalIframeHtml() {


### PR DESCRIPTION
per #153 -- we haven't ever really had a "square" option of the player. This PR makes the difference between the two non-playlist player options very clear (one expands to fill page width, other has fixed width). I also removed some unused code / comments from the builder because that file is very long. 