### PR TITLE
Reduce flicker by rendering placeholder content during feed fetch

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -191,11 +191,9 @@ function scrubElem($, elem, logoName) {
       elem.attr("src", `/assets/images/${logoName}-logo.svg`);
     }
 
-    if (key === '*ngif' && elem.attr(key) !== 'logoSrc' && elem.attr(key) !== 'player.paused' && elem.attr(key) !== 'subscribeUrl') {
+    if (key === '*ngif' && typeof elem.attr('load-render') === 'undefined') {
       elem.remove();
-    }
-
-    if (/^\[|\*|\(/i.test(key)) {
+    } else if (/^\[|\*|\(/i.test(key)) {
       elem.attr(key, null);
     }
   };

--- a/lib/util.js
+++ b/lib/util.js
@@ -146,12 +146,15 @@ exports.ngServe = (port) => {
 function inlineLoadingPlayer(cssPath, htmlPath, logoName) {
   const cssContent = fs.readFileSync(`${__dirname}/${cssPath}`).toString('utf-8');
   const mediaQueries = mediaQ(cssContent).replace(/;/g,' !important;').replace(/\s+/g,' ').replace(/\s?([\{\},:\(\)])\s?/g, '$1').replace(/;\s?\}/g, '}');
-  return inlineCss(`<style>${cssContent}</style>
+  const $ = cheerio.load(`
     <div class="loadingRender">${fs.readFileSync(`${__dirname}/${htmlPath}`)}</div>
+  `, {normalizeWhitespace: true});
+  scrub($, $('.loadingRender').children(), logoName);
+  return inlineCss(`<style>${cssContent}</style>
+      <div class="loadingRender">${$('.loadingRender').html()}</div>
     `, {url: '/'}).then((markup) => {
-    const $ = cheerio.load(markup, {normalizeWhitespace: true});
-    scrub($, $('.loadingRender').children(), logoName);
-    return `<style>${mediaQueries}</style>${$('.loadingRender').html()}`;
+      const $inlined = cheerio.load(markup);
+    return `<style>${mediaQueries}</style>${$inlined('.loadingRender').html()}`;
   });
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -179,11 +179,7 @@ function scrubElem($, elem, logoName) {
     if (/^[\s\n]*$/.test(elem.text())) {
       elem.remove();
     } else {
-      let blocks = [];
-      for (let i=0; i < elem.text().length; i++) {
-        blocks.push("█");
-      }
-      elem[0].data = blocks.join("");
+      elem[0].data = "";
     }
     return;
   }
@@ -191,6 +187,11 @@ function scrubElem($, elem, logoName) {
     if (logoName && key === "[src]" && elem.attr(key) === "logoSrc") {
       elem.attr("src", `/assets/images/${logoName}-logo.svg`);
     }
+
+    if (key === '*ngif' && elem.attr(key) !== 'logoSrc' && elem.attr(key) !== 'player.paused' && elem.attr(key) !== 'subscribeUrl') {
+      elem.remove();
+    }
+
     if (/^\[|\*|\(/i.test(key)) {
       elem.attr(key, null);
     }

--- a/src/app/shared/player/player.component.css
+++ b/src/app/shared/player/player.component.css
@@ -85,7 +85,7 @@ content {
     min-height: 100px;
   }
   .metadata {
-    flex: 0 0 calc(100px + 30px);
+    flex: 0 0 130px;
   }
 }
 
@@ -97,7 +97,7 @@ content {
     min-height: 90px;
   }
   .metadata {
-    flex: 0 0 calc(90px + 30px);
+    flex: 0 0 120px;
   }
 }
 
@@ -109,7 +109,7 @@ content {
     min-height: 125px;
   }
   .metadata {
-    flex: 0 0 calc(125px + 30px);
+    flex: 0 0 155px;
   }
 }
 
@@ -121,7 +121,7 @@ content {
     min-height: 135px;
   }
   .metadata {
-    flex: 0 0 calc(135px + 30px);
+    flex: 0 0 165px;
   }
 }
 
@@ -170,11 +170,11 @@ content {
 
 section {
   flex-grow: 1;
+  width: 1px;
   display: flex;
   flex-flow: column nowrap;
   justify-content: space-between;
   margin: 20px 15px 15px 0;
-  max-width: calc(100% - 180px); /*art width + artwork + section margin = 180px;*/
 }
 
 header {
@@ -215,6 +215,7 @@ h2 {
   width: auto;
   height: 30px;
   display: none;
+  margin-left: 5px;
 }
 
 .logo > img {
@@ -302,6 +303,10 @@ nav a {
   cursor: pointer;
 }
 
+nav a:last-child {
+  margin-right: 0;
+}
+
 nav a:hover {
   color: #1e4e5c;
 }
@@ -385,6 +390,19 @@ play-progress {
 
 .loadingRender play-progress {
   opacity: 0.1;
+}
+
+.loadingRender h1 {
+  width: 200px;
+  background-color: white;
+  border-radius: 20px;
+}
+
+.loadingRender h2 {
+  width: 140px;
+  background-color: white;
+  border-radius: 20px;
+  margin-top: 2px;
 }
 
 @media (max-width: 599px) {

--- a/src/app/shared/player/player.component.html
+++ b/src/app/shared/player/player.component.html
@@ -1,4 +1,4 @@
-<div class="player-container" [class.overlayed]="overlayEnabled">
+<div class="player-container" [class.overlayed]="overlayEnabled" [class.loadingRender]="initialLoading">
   <div class="background-img" [style.background-image]="feedArtworkSafe"></div>
   <content>
     <div class="metadata">

--- a/src/app/shared/player/player.component.html
+++ b/src/app/shared/player/player.component.html
@@ -6,7 +6,7 @@
         <div class="artworkBackground" [class.loaded]="!!artworkSafeLoaded" [style.background-image]="artworkSafeLoaded"></div>
         <img *ngIf="artworkUrl" [src]="artworkUrl" (load)="artworkLoaded()" style="display:none"/>
         <button (click)="togglePlayPause()" id="large-playback-control-button">
-          <img src="/assets/images/large-semi-transparent-play.svg" alt="" *ngIf="player.paused">
+          <img src="/assets/images/large-semi-transparent-play.svg" alt="" *ngIf="player.paused" load-render>
           <img class="pauseButton" src="/assets/images/large-semi-transparent-pause.svg" alt="" *ngIf="!player.paused">
         </button>
       </div>
@@ -16,7 +16,7 @@
             <h1 [title]="title">{{title}}</h1>
             <h2 [title]="subtitle">{{subtitle}}</h2>
           </div>
-          <div class="logo" id="upper-logo"><img *ngIf="logoSrc" [src]="logoSrc" alt=""></div>
+          <div class="logo" id="upper-logo"><img load-render *ngIf="logoSrc" [src]="logoSrc" alt=""></div>
         </header>
         <div class="controls">
           <div class="buttons" (window:keydown)="handleHotkey($event)">
@@ -24,7 +24,7 @@
               <img src="/assets/images/back-5.svg" alt="">
             </button>
             <button (click)="togglePlayPause()" id="playback-control-button">
-              <img src="/assets/images/play.svg" alt="" *ngIf="player.paused">
+              <img src="/assets/images/play.svg" alt="" *ngIf="player.paused" load-render>
               <img class="pauseButton" src="/assets/images/pause.svg" alt="" *ngIf="!player.paused">
             </button>
             <button (click)="seekBy(30)" id="forward-control-button">
@@ -43,7 +43,7 @@
           </div>
 
           <nav>
-            <a [href]="subscribeUrl" *ngIf="subscribeUrl" [target]="subscribeTarget">
+            <a [href]="subscribeUrl" load-render *ngIf="subscribeUrl || initialLoading" [target]="subscribeTarget">
               <img class="nav-button" src="/assets/images/plus-sign-subscribe.svg" alt="">
             </a>
             <a (click)="showShareModal()" id="share-button">
@@ -53,7 +53,7 @@
               <img src="/assets/images/skip.svg" alt="">
             </button>
           </nav>
-          <div class="logo" id="lower-logo"><img *ngIf="logoSrc" [src]="logoSrc" alt=""></div>
+          <div class="logo" id="lower-logo"><img load-render *ngIf="logoSrc" [src]="logoSrc" alt=""></div>
         </div>
       </section>
     </div>

--- a/src/app/shared/player/player.component.ts
+++ b/src/app/shared/player/player.component.ts
@@ -54,6 +54,8 @@ export class PlayerComponent implements OnInit, OnChanges {
 
   logoSrc: string;
 
+  initialLoading = true;
+
   constructor(private sanitizer: DomSanitizer, private sessionService: MediaSessionService) {}
 
   ngOnInit() {
@@ -102,6 +104,7 @@ export class PlayerComponent implements OnInit, OnChanges {
   ngOnChanges(changes: any) {
     if (this.player) {
       if (changes.audioUrl || changes.title || changes.subtitle) {
+        this.initialLoading = false;
         this.logger = new Logger(this.player, this.title, this.subtitle);
         this.sessionService.setMediaMetadata(this.title, this.subtitle, null, this.feedArtworkUrl);
       }


### PR DESCRIPTION
Also changes placeholder content to be a little prettier (rounded corners)
and fixes styles a little so that the logo doesn't move to the left when the
overlay is active and the album art shrinks (this turned out to be more of a
pain than it should have been, I am happy to walk through it)

Teeing up a few other fun changes.