### PR TITLE
Don't preload audio

### DIFF
--- a/src/app/embed/adapters/adapter.properties.ts
+++ b/src/app/embed/adapters/adapter.properties.ts
@@ -2,6 +2,7 @@ import { Observable } from 'rxjs/Observable';
 
 export const PropNames = [
   'audioUrl',
+  'duration',
   'title',
   'subtitle',
   'subscribeUrl',

--- a/src/app/embed/embed.component.ts
+++ b/src/app/embed/embed.component.ts
@@ -20,7 +20,7 @@ const PYM_CHILD_ID_PARAM = 'childId';
     <play-player [feedArtworkUrl]="feedArtworkUrl" [audioUrl]="audioUrl" [title]="title" [subtitle]="subtitle"
       [subscribeUrl]="subscribeUrl" [subscribeTarget]="subscribeTarget" [artworkUrl]="artworkUrl" (share)="showModal()"
       [showPlaylist]="showPlaylist" [episodes]="episodes" (play)="onPlay($event)" (pause)="onPause($event)"
-      (ended)="onEnded($event)" (download)="onDownload($event)">
+      (ended)="onEnded($event)" (download)="onDownload($event)" [duration]="duration">
       <ng-template let-dismiss="dismiss">
         <div class="app-overlay" (window:keydown)="handleKeypress($event)">
           <p>Never miss an episode from <strong>{{this.subtitle}}</strong> and other great podcasts when you download the free RadioPublic app.</p>
@@ -45,6 +45,7 @@ export class EmbedComponent implements OnInit {
 
   // player params
   audioUrl: string;
+  duration: number;
   title: string;
   subtitle: string;
   subscribeUrl: string;
@@ -115,6 +116,7 @@ export class EmbedComponent implements OnInit {
 
   private assignEpisodePropertiesToPlayer(properties: AdapterProperties) {
     this.audioUrl = ( properties.audioUrl || this.audioUrl );
+    this.duration = ( properties.duration || this.duration || 0 );
     this.title = ( properties.title || this.title );
     this.subtitle = ( properties.subtitle || this.subtitle );
     this.subscribeUrl = ( properties.subscribeUrl || this.subscribeUrl );

--- a/src/app/embed/embed.component.ts
+++ b/src/app/embed/embed.component.ts
@@ -23,14 +23,20 @@ const PYM_CHILD_ID_PARAM = 'childId';
       (ended)="onEnded($event)" (download)="onDownload($event)" [duration]="duration">
       <ng-template let-dismiss="dismiss">
         <div class="app-overlay" (window:keydown)="handleKeypress($event)">
-          <p>Never miss an episode from <strong>{{this.subtitle}}</strong> and other great podcasts when you download the free RadioPublic app.</p>
+          <p>Never miss an episode from <strong>{{this.subtitle}}</strong>
+            and other great podcasts when you download the free RadioPublic app.</p>
           <ul class="app-selection">
-            <li *ngIf="!isiOSDevice"><a [href]="playStoreLink()" [target]="subscribeTarget"><img src="/assets/images/google-play.png" alt="Google Play Store" /></a></li>
-            <li *ngIf="!isAndroidDevice"><a [href]="appStoreLink()" [target]="subscribeTarget"><img src="/assets/images/app-store.svg" alt="App Store" /></a></li>
-            <li *ngIf="isiOSDevice">or the <a [href]="playStoreLink()" [target]="subscribeTarget">Google Play Store</a></li>
-            <li *ngIf="isAndroidDevice">or the <a href="appStoreLink()" [target]="subscribeTarget">App Store</a></li>
+            <li *ngIf="!isiOSDevice"><a [href]="playStoreLink()"
+              [target]="subscribeTarget"><img src="/assets/images/google-play.png" alt="Google Play Store" /></a></li>
+            <li *ngIf="!isAndroidDevice"><a [href]="appStoreLink()"
+              [target]="subscribeTarget"><img src="/assets/images/app-store.svg" alt="App Store" /></a></li>
+            <li *ngIf="isiOSDevice">or the <a [href]="playStoreLink()"
+              [target]="subscribeTarget">Google Play Store</a></li>
+            <li *ngIf="isAndroidDevice">or the <a href="appStoreLink()"
+              [target]="subscribeTarget">App Store</a></li>
           </ul>
-          <p class="aside" *ngIf="downloadRequested">You can also <a [href]="audioUrl" [target]="subscribeTarget">download the audio file</a> if you're on a computer.</p>
+          <p class="aside" *ngIf="downloadRequested">You can also <a [href]="audioUrl"
+            [target]="subscribeTarget">download the audio file</a> if you're on a computer.</p>
         </div>
       </ng-template>
     </play-player>

--- a/src/app/shared/audio/extendable-audio.ts
+++ b/src/app/shared/audio/extendable-audio.ts
@@ -18,7 +18,6 @@ export class ExtendableAudio {
   constructor(url) {
     if (typeof window['Audio'] !== 'undefined') {
       this._audio = new Audio();
-      this._audio.preload = 'none';
     } else {
       // Basically make audio a noop on phantom or browsers with no Audio support
       this._audio = ({addEventListener: noop} as any) as HTMLAudioElement;

--- a/src/app/shared/audio/extendable-audio.ts
+++ b/src/app/shared/audio/extendable-audio.ts
@@ -19,6 +19,7 @@ export class ExtendableAudio {
   constructor(url) {
     if (typeof window['Audio'] !== 'undefined') {
       this._audio = new Audio();
+      this._audio.preload = 'none';
     } else {
       // Basically make audio a noop on phantom or browsers with no Audio support
       this._audio = ({addEventListener: noop} as any) as HTMLAudioElement;

--- a/src/app/shared/audio/extendable-audio.ts
+++ b/src/app/shared/audio/extendable-audio.ts
@@ -1,6 +1,6 @@
 /// <reference path="./extendable-audio.d.ts" />
 
-const SKIP_PROPERTIES = ['dispatchEvent', 'addEventListener', 'removeEventListener'];
+const SKIP_PROPERTIES = ['dispatchEvent', 'addEventListener', 'removeEventListener', 'paused'];
 
 export class ExtendableAudio {
 
@@ -13,7 +13,6 @@ export class ExtendableAudio {
   ondurationchange: Function;
   ontimeupdate: Function;
   onseeking: Function;
-  paused: boolean;
   volume: number;
 
   constructor(url) {
@@ -64,6 +63,10 @@ export class ExtendableAudio {
 
   removeEventListener() {
     return this._documentFragment.removeEventListener.apply(this._documentFragment, arguments);
+  }
+
+  get paused(): boolean {
+    return this._audio.paused;
   }
 
 }

--- a/src/app/shared/dovetail/dovetail-audio.ts
+++ b/src/app/shared/dovetail/dovetail-audio.ts
@@ -60,7 +60,7 @@ export class DovetailAudio extends ExtendableAudio {
   private _imgElem: HTMLImageElement;
 
   constructor(url: string) {
-    super(url);
+    super(undefined);
     this._audio.addEventListener(ERROR, this.listenerOnError.bind(this));
     this._audio.addEventListener(DURATION_CHANGE, this.listenerOnDurationChange.bind(this));
     this._audio.addEventListener(ENDED, this.listenerOnEnded.bind(this));
@@ -68,20 +68,27 @@ export class DovetailAudio extends ExtendableAudio {
     this.$$forwardEvents(PROXIED_EVENTS);
     this.finishConstructor();
     this.addEventListener(SEGMENT_END, this.$$logImpression.bind(this));
+    this._toSetUrl = url;
   }
 
   play(): Promise<void> {
-    this.$$sendEvent(PLAY);
-    if (this._dovetailLoading) {
-      return new Promise<void>(resolve => {
-        this.resumeOnLoad = resolve;
-      });
-    } else if (this.arrangement.entries[this.index].unplayable) {
-      return new Promise<void>(resolve => {
-        this.skipToFile(this.index + 1, resolve);
-      });
+    if (this._toSetUrl) {
+      this.setSegments(this.fallback(this._toSetUrl));
+      this._toSetUrl = null;
+      return this.play();
     } else {
-      return this.playItSafe();
+      this.$$sendEvent(PLAY);
+      if (this._dovetailLoading) {
+        return new Promise<void>(resolve => {
+          this.resumeOnLoad = resolve;
+        });
+      } else if (this.arrangement.entries[this.index] && this.arrangement.entries[this.index].unplayable) {
+        return new Promise<void>(resolve => {
+          this.skipToFile(this.index + 1, resolve);
+        });
+      } else {
+        return this.playItSafe();
+      }
     }
   }
 
@@ -163,24 +170,31 @@ export class DovetailAudio extends ExtendableAudio {
       this._dovetailOriginalUrl = url;
       url += (url.indexOf('?') < 0 ? '?' : '&') + 'debug';
     }
-    this.setSegments(this.fallback(url));
+    if (this._audio.paused) {
+      this._toSetUrl = url;
+    } else {
+      this.setSegments(this.fallback(url));
+    }
   }
 
-  private playItSafe() {
+  private playItSafe(): Promise<void> {
+    let safePlay = new Promise<void>(resolve => resolve(this._audio.play()));
+    return safePlay.then(
+      () => null,
+      err => this.playErrorHandler(err)
+    );
+  }
+
+  private playErrorHandler(err): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      this._audio.play().then(
-        () => resolve(),
-        err => {
-          if (this._dovetailLoading) {
-            this.resumeOnLoad = resolve;
-          } else if (this._dovetailOriginalUrl && err.name === 'NotSupportedError') {
-            this._dovetailLoading = true;
-            this.resumeOnLoad = resolve;
-          } else {
-            reject(err);
-          }
-        }
-      );
+      if (this._dovetailLoading) {
+        this.resumeOnLoad = resolve;
+      } else if (this._dovetailOriginalUrl && err.name === 'NotSupportedError') {
+        this._dovetailLoading = true;
+        this.resumeOnLoad = resolve;
+      } else {
+        reject(err);
+      }
     });
   }
 

--- a/src/app/shared/dovetail/dovetail-audio.ts
+++ b/src/app/shared/dovetail/dovetail-audio.ts
@@ -81,8 +81,20 @@ export class DovetailAudio extends ExtendableAudio {
         this.skipToFile(this.index + 1, resolve);
       });
     } else {
-      return new Promise<void>(resolve => {
-        resolve(this._audio.play());
+      return new Promise<void> ((resolve, reject) => {
+        this._audio.play().then(
+          () => resolve(),
+          err => {
+            if (this._dovetailLoading) {
+              this.resumeOnLoad = resolve;
+            } else if (this._dovetailOriginalUrl && err.name === 'NotSupportedError') {
+              this._dovetailLoading = true;
+              this.resumeOnLoad = resolve;
+            } else {
+              reject(err);
+            }
+          }
+        );
       });
     }
   }

--- a/src/app/shared/dovetail/dovetail-audio.ts
+++ b/src/app/shared/dovetail/dovetail-audio.ts
@@ -108,6 +108,10 @@ export class DovetailAudio extends ExtendableAudio {
     }
   }
 
+  get paused(): boolean {
+    return this._audio.paused && !this._dovetailLoading;
+  }
+
   get playbackRate() {
     if (!this._playbackRate) {
       this._playbackRate = this._audio.playbackRate;

--- a/src/app/shared/player/player.component.html
+++ b/src/app/shared/player/player.component.html
@@ -62,14 +62,14 @@
     </div>
 
     <div class="scrubber" (window:keydown)="handleHotkey($event)">
-      <span class="playback-progress" [class.loaded]="duration | async">{{currentTime | async | duration}}</span>
+      <span class="playback-progress" [class.loaded]="currentDuration | async">{{currentTime | async | duration}}</span>
       <play-progress
         [value]="currentTime | async"
-        [maximum]="duration | async"
+        [maximum]="currentDuration | async"
         (seek)="onSeek($event)"
         (scrubbing)="onScrub($event)">
       </play-progress>
-      <span class="duration" [class.loaded]="duration | async ">{{duration | async | duration}}</span>
+      <span class="duration" [class.loaded]="currentDuration | async ">{{currentDuration | async | duration}}</span>
     </div>
 
     <div class="overlayContent"><ng-container *ngTemplateOutlet="overlayTemplate; context:overlayContext"></ng-container></div>

--- a/src/app/shared/player/player.component.html
+++ b/src/app/shared/player/player.component.html
@@ -61,7 +61,7 @@
       </section>
     </div>
 
-    <div class="scrubber" (window:keydown)="handleHotkey($event)">
+    <div class="scrubber">
       <span class="playback-progress" [class.loaded]="currentDuration | async">{{currentTime | async | duration}}</span>
       <play-progress
         [value]="currentTime | async"

--- a/src/app/shared/player/player.component.ts
+++ b/src/app/shared/player/player.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, Output, OnInit, OnChanges, ContentChild, TemplateRef } from '@angular/core';
 import { DomSanitizer, SafeStyle } from '@angular/platform-browser';
-import { Observable, Observer, ReplaySubject } from 'rxjs';
+import { Observable, Observer } from 'rxjs';
 import { MediaSessionService } from './mediasession.service';
 import 'player.js';
 
@@ -60,7 +60,7 @@ export class PlayerComponent implements OnInit, OnChanges {
   private isHeld: boolean;
 
   currentTime: Observable<number>;
-  currentDuration: ReplaySubject<number>;
+  currentDuration: Observable<number>;
 
   logoSrc: string;
 

--- a/src/app/shared/player/player.component.ts
+++ b/src/app/shared/player/player.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, Output, OnInit, OnChanges, ContentChild, TemplateRef } from '@angular/core';
 import { DomSanitizer, SafeStyle } from '@angular/platform-browser';
-import { Observable, Observer } from 'rxjs';
+import { Observable, Observer, ReplaySubject } from 'rxjs';
 import { MediaSessionService } from './mediasession.service';
 import 'player.js';
 
@@ -24,6 +24,7 @@ export interface EndedEvent extends Event {
 export class PlayerComponent implements OnInit, OnChanges {
 
   @Input() audioUrl: string;
+  @Input() duration: number;
   @Input() title: string;
   @Input() subtitle: string;
   @Input() subscribeUrl: string;
@@ -59,7 +60,7 @@ export class PlayerComponent implements OnInit, OnChanges {
   private isHeld: boolean;
 
   currentTime: Observable<number>;
-  duration: Observable<number>;
+  currentDuration: ReplaySubject<number>;
 
   logoSrc: string;
 
@@ -71,6 +72,7 @@ export class PlayerComponent implements OnInit, OnChanges {
   overlayContext = {dismiss: this.dismissOverlay.bind(this)};
 
   private isEnded = false;
+  private currentDurationObserver: Observer<number>;
 
   constructor(private sanitizer: DomSanitizer, private sessionService: MediaSessionService) {}
 
@@ -120,8 +122,9 @@ export class PlayerComponent implements OnInit, OnChanges {
       this.feedArtworkSafe = this.sanitizer.bypassSecurityTrustStyle(`none`);
     }
 
-    this.duration = Observable.create((observer: Observer<number>) => {
-      observer.next(0);
+    this.currentDuration = Observable.create((observer: Observer<number>) => {
+      this.currentDurationObserver = observer;
+      observer.next(this.duration);
       this.player.ondurationchange = () => observer.next(this.player.duration);
       return (): void => this.player.ondurationchange = undefined;
     }).share();
@@ -147,6 +150,9 @@ export class PlayerComponent implements OnInit, OnChanges {
         this.logger = new Logger(this.player, this.title, this.subtitle);
         this.sessionService.setMediaMetadata(this.title, this.subtitle, null, this.feedArtworkUrl);
       }
+    }
+    if (changes.duration && this.currentDurationObserver) {
+      this.currentDurationObserver.next(this.duration);
     }
     if (changes.feedArtworkUrl) {
       this.feedArtworkSafe = this.sanitizer.bypassSecurityTrustStyle(`url('${this.feedArtworkUrl}')`);


### PR DESCRIPTION
See #155.

- Don't fetch the mp3 upfront, as it causes over-counting in Podtrac.
- Use the itunes duration for the initially displayed value
- Fix bug with too many keydown handlers (hitting space would trigger 2 events ... play, then immediately pause)