### PR TITLE
Export the DovetailAudio class as a named export

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export { DovetailAudio } from './src/app/shared/dovetail/dovetail-audio';

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "serve": "node lib/server.js dist"
   },
   "private": true,
+  "main": "index.ts",
   "dependencies": {
     "@angular/animations": "^4.0.0",
     "@angular/cli": "^1.0.0",


### PR DESCRIPTION
Greetings! We're preparing to update play.radiopublic.com to add features that make it easy to switch back and forth between the web and our native apps, and as part of that, I'll be creating a player that integrates with those features. Chris asked that I utilize this project's `DovetailAudio` class in the new player, so this PR adds two lines of code to export that class. I've verified that with this change, we can import and compile the class in our project using [ts-loader](https://github.com/TypeStrong/ts-loader). I'm definitely open to other ways of exposing this class if you prefer a different approach, so please let me know what you think.