### PR TITLE
If an item `guid` tag doesn't exist, fall back to `rp:item-id`

### DIFF
--- a/src/app/embed/adapters/draper.adapter.ts
+++ b/src/app/embed/adapters/draper.adapter.ts
@@ -58,4 +58,8 @@ export class DraperAdapter extends FeedAdapter {
     return `https://draper.radiopublic.com/transform?program_id=${feedId}`;
   }
 
+  protected getItemGuid(el: Element | XMLDocument): string {
+    // If the item has no guid, fall back to the rp:item-id added by Draper.
+    return super.getItemGuid(el) || this.getTagText(el, 'rp:item-id');
+  }
 }

--- a/src/app/embed/adapters/feed.adapter.ts
+++ b/src/app/embed/adapters/feed.adapter.ts
@@ -83,7 +83,7 @@ export class FeedAdapter implements DataAdapter {
 
     if (typeof episodeGuid !== 'undefined') {
       for (let i = 0; i < items.length; i++) {
-        let itemGuid = this.getTagText(items[i], 'guid');
+        let itemGuid = this.getItemGuid(items[i]);
         if (itemGuid) {
           if (!this.isEncoded(itemGuid) && this.isEncoded(episodeGuid)) {
             itemGuid = this.encodeGuid(itemGuid);
@@ -149,6 +149,10 @@ export class FeedAdapter implements DataAdapter {
 
   protected encodeGuid(guid): string {
     return `${GUID_PREFIX}${sha1.hash(guid)}`;
+  }
+
+  protected getItemGuid(el: Element | XMLDocument): string {
+    return this.getTagText(el, 'guid');
   }
 
   protected getTagText(el: Element | XMLDocument, tag: string): string {

--- a/src/app/embed/adapters/feed.adapter.ts
+++ b/src/app/embed/adapters/feed.adapter.ts
@@ -83,8 +83,7 @@ export class FeedAdapter implements DataAdapter {
 
     if (typeof episodeGuid !== 'undefined') {
       for (let i = 0; i < items.length; i++) {
-        // If the item doesn't include a `guid`, fall back to RadioPublic's `rp:item-id` tag.
-        let itemGuid = this.getTagText(items[i], 'guid') || this.getTagText(items[i], 'rp:item-id');
+        let itemGuid = this.getTagText(items[i], 'guid');
         if (itemGuid) {
           if (!this.isEncoded(itemGuid) && this.isEncoded(episodeGuid)) {
             itemGuid = this.encodeGuid(itemGuid);

--- a/src/app/embed/adapters/feed.adapter.ts
+++ b/src/app/embed/adapters/feed.adapter.ts
@@ -83,7 +83,8 @@ export class FeedAdapter implements DataAdapter {
 
     if (typeof episodeGuid !== 'undefined') {
       for (let i = 0; i < items.length; i++) {
-        let itemGuid = this.getTagText(items[i], 'guid');
+        // If the item doesn't include a `guid`, fall back to RadioPublic's `rp:item-id` tag.
+        let itemGuid = this.getTagText(items[i], 'guid') || this.getTagText(items[i], 'rp:item-id');
         if (itemGuid) {
           if (!this.isEncoded(itemGuid) && this.isEncoded(episodeGuid)) {
             itemGuid = this.encodeGuid(itemGuid);


### PR DESCRIPTION
When RP's Draper service detects that an rss `item` is missing a `guid`, it adds an `rp:item-id` value that's computed using the item's `title` and `pubDate`. This PR updates the feed adapter so that if an item doesn't include a `guid`, it falls back to `rp:item-id`, allowing guidless feeds to continue to work on RadioPublic.