### PR TITLE
Don't install docker-compose

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,11 +5,6 @@ env:
     PRX_ECR_REPOSITORY: "play.prx.org"
     PRX_ECR_CONFIG_PARAMETERS: "PlayEcrImageTag"
 phases:
-  install:
-    commands:
-      - 'echo "Installing docker-compose..."'
-      - 'COMPOSE="https://github.com/docker/compose/releases/download/1.11.2/docker-compose-$(uname -s)-$(uname -m)" && curl -sL $COMPOSE -o /usr/local/bin/docker-compose'
-      - "chmod +x /usr/local/bin/docker-compose"
   build:
     commands:
       - "cd $(ls -d */|head -n 1)"


### PR DESCRIPTION
Evidently docker-compose is included in the AWS-provided build
environment now