### PR TITLE
Playlist download links

### DIFF
--- a/src/app/embed/embed.component.ts
+++ b/src/app/embed/embed.component.ts
@@ -20,7 +20,7 @@ const PYM_CHILD_ID_PARAM = 'childId';
     <play-player [feedArtworkUrl]="feedArtworkUrl" [audioUrl]="audioUrl" [title]="title" [subtitle]="subtitle"
       [subscribeUrl]="subscribeUrl" [subscribeTarget]="subscribeTarget" [artworkUrl]="artworkUrl" (share)="showModal()"
       [showPlaylist]="showPlaylist" [episodes]="episodes" (play)="onPlay($event)" (pause)="onPause($event)"
-      (ended)="onEnded($event)" (download)="onDownload($event)" [duration]="duration">
+      (ended)="onEnded($event)" (download)="onDownload($event)" (downloadUrl)="onDownloadUrl($event)" [duration]="duration">
       <ng-template let-dismiss="dismiss">
         <div class="app-overlay" (window:keydown)="handleKeypress($event)">
           <p>Never miss an episode from <strong>{{this.subtitle}}</strong>
@@ -35,7 +35,7 @@ const PYM_CHILD_ID_PARAM = 'childId';
             <li *ngIf="isAndroidDevice">or the <a href="appStoreLink()"
               [target]="subscribeTarget">App Store</a></li>
           </ul>
-          <p class="aside" *ngIf="downloadRequested">You can also <a [href]="audioUrl"
+          <p class="aside" *ngIf="downloadRequested">You can also <a [href]="downloadAudioUrl"
             [target]="subscribeTarget">download the audio file</a> if you're on a computer.</p>
         </div>
       </ng-template>
@@ -48,6 +48,7 @@ export class EmbedComponent implements OnInit {
   showShareModal = false;
   hasInteracted = false;
   downloadRequested = false;
+  downloadAudioUrl: string;
 
   // player params
   audioUrl: string;
@@ -110,6 +111,10 @@ export class EmbedComponent implements OnInit {
     e.preventDefault();
     this.downloadRequested = true;
     this.player.displayOverlay();
+  }
+
+  onDownloadUrl(url: string) {
+    this.downloadAudioUrl = url;
   }
 
   playStoreLink() {

--- a/src/app/shared/player/player.component.ts
+++ b/src/app/shared/player/player.component.ts
@@ -38,6 +38,7 @@ export class PlayerComponent implements OnInit, OnChanges {
   @Output() pause = new EventEmitter<Event>();
   @Output() ended = new EventEmitter<EndedEvent>();
   @Output() download = new EventEmitter<Event>();
+  @Output() downloadUrl = new EventEmitter<string>();
 
   artworkSafe: SafeStyle;
   feedArtworkSafe: SafeStyle;
@@ -218,6 +219,7 @@ export class PlayerComponent implements OnInit, OnChanges {
       this.artworkUrl = newEpisode.artworkUrl;
       this.setEpisodeArtworkSafe();
       this.audioUrl = this.player.src = newEpisode.audioUrl;
+      this.downloadUrl.emit(this.audioUrl);
       this.player.addEventListener('canplay', e => {
         this.player.play();
         this.player.removeEventListener();
@@ -343,6 +345,7 @@ export class PlayerComponent implements OnInit, OnChanges {
   }
 
   requestDownload(event) {
+    this.downloadUrl.emit(this.audioUrl);
     this.download.emit(event);
   }
 


### PR DESCRIPTION
See #192.

The top-level EmbedComponent has an `audioUrl`, but it represents the _first_ episode audio to be played back.  When cycling through the playlist, it's the 2nd-level PlayerComponent `audioUrl` that changes.

This PR keeps that top-level param intact, but adds a `downloadUrl` output on the PlayerComponent, so it cat emit the actual url being played. 