### PR TITLE
fixes bug with partially matched guids

### DIFF
--- a/src/app/embed/adapters/feed.adapter.spec.ts
+++ b/src/app/embed/adapters/feed.adapter.spec.ts
@@ -28,6 +28,12 @@ describe('FeedAdapter', () => {
           <feedburner:origEnclosureLink>http://item1/original.mp3</feedburner:origEnclosureLink>
         </item>
         <item>
+          <guid isPermaLink="false">guid-23</guid>
+          <itunes:duration>34:03:05</itunes:duration>
+          <title>Title #23</title>
+          <enclosure url="http://item23/enclosure.mp3"/>
+        </item>
+        <item>
           <guid isPermaLink="false">guid-2</guid>
           <itunes:duration>38:00:12</itunes:duration>
           <title>Title #2</title>
@@ -120,6 +126,12 @@ describe('FeedAdapter', () => {
   it('defaults to the first item', injectHttp((feed: FeedAdapter, mocker) => {
     mocker(TEST_FEED);
     expect(getProperties(feed, 'whatev').title).toEqual('Title #1');
+  }));
+
+  it('looks for a fully matched guid', injectHttp((feed: FeedAdapter, mocker) => {
+    mocker(TEST_FEED);
+    let props = getProperties(feed, 'http://some.where/feed.xml', 'guid-2', 3);
+    expect(props.episodes[2].title).toEqual('Title #2');
   }));
 
 });

--- a/src/app/embed/adapters/feed.adapter.ts
+++ b/src/app/embed/adapters/feed.adapter.ts
@@ -88,7 +88,7 @@ export class FeedAdapter implements DataAdapter {
           if (!this.isEncoded(itemGuid) && this.isEncoded(episodeGuid)) {
             itemGuid = this.encodeGuid(itemGuid);
           }
-          if (itemGuid.indexOf(episodeGuid) !== -1) {
+          if (itemGuid === episodeGuid) {
             return items[i];
           }
         }


### PR DESCRIPTION
The Allusionist has some older episodes that have guids that are a partial match to more recent episode guids in the feed. The player was grabbing the first item with a partially matched guid. This fix looks for a full string match.