### PR TITLE
Non-feed audio loading indicator

### DIFF
--- a/src/app/shared/dovetail/dovetail-audio.ts
+++ b/src/app/shared/dovetail/dovetail-audio.ts
@@ -338,13 +338,13 @@ export class DovetailAudio extends ExtendableAudio {
   }
 
   private $$logDownload(event: DovetailSegmentEvent) {
-    if (event.segment.trackBefore()) {
+    if (event.segment && event.segment.trackBefore()) {
       this.$$debug(`Download: ${event.segment.id}`);
     }
   }
 
   private $$logImpression(event: DovetailSegmentEvent) {
-    if (event.segment.trackAfter()) {
+    if (event.segment && event.segment.trackAfter()) {
       this.$$debug(`Impress: ${event.segment.id}`);
     }
   }

--- a/src/app/shared/player/player.component.ts
+++ b/src/app/shared/player/player.component.ts
@@ -142,6 +142,10 @@ export class PlayerComponent implements OnInit, OnChanges {
       this.logoSrc = '';
     }
     playerjsAdapter(this.player).ready();
+
+    if (this.audioUrl) {
+      this.initialLoading = false;
+    }
   }
 
   ngOnChanges(changes: any) {


### PR DESCRIPTION
The title/subtitle overlay was never disappearing for non-feed audioUrls.  (If you used the builder and specify the individual query params).

This gets rid of that overlay, and also prevents a bug where non-dovetail audio tries to log impressions/downloads.