### PR TITLE
Use XML namespace URIs directly for lookups

### DIFF
--- a/src/app/embed/adapters/draper.adapter.ts
+++ b/src/app/embed/adapters/draper.adapter.ts
@@ -5,6 +5,8 @@ import { EMBED_FEED_ID_PARAM, EMBED_EPISODE_GUID_PARAM } from './../embed.consta
 import { AdapterProperties } from './adapter.properties';
 import { FeedAdapter } from './feed.adapter';
 
+const RADIOPUBLIC_NAMESPACE = 'https://www.w3id.org/rp/v1';
+
 @Injectable()
 export class DraperAdapter extends FeedAdapter {
 
@@ -41,17 +43,17 @@ export class DraperAdapter extends FeedAdapter {
 
   processDoc(doc: XMLDocument, props: AdapterProperties = {}): AdapterProperties {
     props = super.processDoc(doc, props);
-    props.feedArtworkUrl = this.getTagAttributeNS(doc, 'rp', 'image', 'href')
+    props.feedArtworkUrl = this.getTagAttributeNS(doc, RADIOPUBLIC_NAMESPACE, 'image', 'href')
                         || props.feedArtworkUrl;
-    props.subscribeUrl = `https://play.radiopublic.com/${this.getTagTextNS(doc, 'rp', 'program-id')}`;
+    props.subscribeUrl = `https://play.radiopublic.com/${this.getTagTextNS(doc, RADIOPUBLIC_NAMESPACE, 'program-id')}`;
     return props;
   }
 
   processEpisode(item: Element, props: AdapterProperties = {}): AdapterProperties {
     props = super.processEpisode(item, props);
-    props.artworkUrl = this.getTagAttributeNS(item, 'rp', 'image', 'href')
+    props.artworkUrl = this.getTagAttributeNS(item, RADIOPUBLIC_NAMESPACE, 'image', 'href')
                     || props.artworkUrl;
-    props.duration = parseInt(this.getTagTextNS(item, 'rp', 'duration') || (props.duration||0).toString(), 10);
+    props.duration = parseInt(this.getTagTextNS(item, RADIOPUBLIC_NAMESPACE, 'duration') || (props.duration || 0).toString(), 10);
     return props;
   }
 

--- a/src/app/embed/adapters/feed.adapter.ts
+++ b/src/app/embed/adapters/feed.adapter.ts
@@ -11,6 +11,9 @@ import { sha1 } from './sha1';
 
 const GUID_PREFIX = 's1!';
 const CDATA = '<![CDATA[';
+const ATOM_NAMESPACE = 'http://www.w3.org/2005/Atom';
+const ITUNES_NAMESPACE = 'http://www.itunes.com/dtds/podcast-1.0.dtd';
+const FEEDBURNER_NAMESPACE = 'http://rssnamespace.org/feedburner/ext/1.0';
 
 @Injectable()
 export class FeedAdapter implements DataAdapter {
@@ -112,17 +115,18 @@ export class FeedAdapter implements DataAdapter {
 
   processDoc(doc: XMLDocument, props: AdapterProperties = {}): AdapterProperties {
     props.subtitle = this.getTagText(doc, 'title');
-    props.subscribeUrl = this.getTagAttributeNS(doc, 'atom', 'link', 'href'); // TODO: what if this isn't the first link?
-    props.feedArtworkUrl = this.getTagAttributeNS(doc, 'itunes', 'image', 'href');
+    props.subscribeUrl = this.getTagAttributeNS(doc, ATOM_NAMESPACE, 'link', 'href'); // TODO: what if this isn't the first link?
+    props.feedArtworkUrl = this.getTagAttributeNS(doc, ITUNES_NAMESPACE, 'image', 'href');
+
     return props;
   }
 
   processEpisode(item: Element, props: AdapterProperties = {}): AdapterProperties {
     props.title = this.getTagText(item, 'title');
-    props.audioUrl = this.getTagTextNS(item, 'feedburner', 'origEnclosureLink')
+    props.audioUrl = this.getTagTextNS(item, FEEDBURNER_NAMESPACE, 'origEnclosureLink')
                   || this.getTagAttribute(item, 'enclosure', 'url');
-    props.artworkUrl = this.getTagAttributeNS(item, 'itunes', 'image', 'href');
-    let duration = this.getTagTextNS(item, 'itunes', 'duration');
+    props.artworkUrl = this.getTagAttributeNS(item, ITUNES_NAMESPACE, 'image', 'href');
+    const duration = this.getTagTextNS(item, ITUNES_NAMESPACE, 'duration');
     props.duration = duration ? this.durationInSec(duration) : 0;
     return props;
   }
@@ -162,9 +166,9 @@ export class FeedAdapter implements DataAdapter {
     }
   }
 
-  protected getTagTextNS(el: Element | XMLDocument, ns: string, tag: string): string {
-    let namespace = el.lookupNamespaceURI(ns);
-    let found = el.getElementsByTagNameNS(namespace, tag);
+
+  protected getTagTextNS(el: Element | XMLDocument, namespace: string, tag: string): string {
+    const found = el.getElementsByTagNameNS(namespace, tag);
     if (found.length) {
       return found[0].textContent;
     }
@@ -177,9 +181,8 @@ export class FeedAdapter implements DataAdapter {
     }
   }
 
-  protected getTagAttributeNS(el: Element | XMLDocument, ns: string, tag: string, attr: string): string {
-    let namespace = el.lookupNamespaceURI(ns);
-    let found = el.getElementsByTagNameNS(namespace, tag);
+  protected getTagAttributeNS(el: Element | XMLDocument, namespace: string, tag: string, attr: string): string {
+    const found = el.getElementsByTagNameNS(namespace, tag);
     if (found.length) {
       return found[0].getAttribute(attr);
     }


### PR DESCRIPTION
Previously, tag lookups were done by commonly-used namespace shortnames. This change uses the namespace itself, instead.