### PR TITLE
Seasons and serial order

### DIFF
--- a/src/app/builder/builder.component.css
+++ b/src/app/builder/builder.component.css
@@ -110,6 +110,7 @@ label {
 }
 
 .builder-step input[type='text'],
+.builder-step input[type='number'],
 .builder-step input[type='url'] {
   font-size: 14px;
   margin: 5px 0;
@@ -158,7 +159,8 @@ label {
   display: block;
 }
 
-.builder-step fieldset input[type='text'] {
+.builder-step fieldset input[type='text'],
+.builder-step fieldset input[type='number'] {
   margin-top: 0;
 }
 

--- a/src/app/builder/builder.component.html
+++ b/src/app/builder/builder.component.html
@@ -64,8 +64,12 @@
               <option value="all">All episodes in playlist</option>
             </select>
           </fieldset>
-          <fieldset *ngIf="playPlaylist">
-            <p>Optionally filter to a single itunes:season of your podcast. Leave blank to include all episodes.</p>
+          <label *ngIf="playPlaylist">
+            <input type="checkbox" [checked]="playSeason" (change)="togglePlaySeason()">
+            Play a single season
+          </label>
+          <fieldset *ngIf="playSeason">
+            <p>Optionally filter to a single itunes:season of your podcast.</p>
             <input type="number" [(ngModel)]="props.playlistSeason" placeholder="Season Number" min="1" max="999">
           </fieldset>
         </fieldset>

--- a/src/app/builder/builder.component.html
+++ b/src/app/builder/builder.component.html
@@ -55,7 +55,7 @@
             Make It A Playlist
           </label>
           <fieldset *ngIf="playPlaylist">
-            <p>This will create a playlist from your RSS feed, starting with the most recent episode. The list of upcoming episodes will appear underneath the regular player.</p>
+            <p>This will create a playlist from your RSS feed. The list of upcoming episodes will appear underneath the regular player.</p>
             <select [(ngModel)]="props.playlistLength">
               <option value="5">5 episodes in playlist</option>
               <option value="10">10 episodes in playlist</option>
@@ -63,6 +63,11 @@
               <option value="20">20 episodes in playlist</option>
               <option value="all">All episodes in playlist</option>
             </select>
+          </fieldset>
+          <fieldset *ngIf="playPlaylist">
+            <p>Optionally play a single itunes:season of your podcast. Leave blank to include all episodes</p>
+            <input type="number" [(ngModel)]="props.playlistSeason"
+              placeholder="Season Number" min="1" max="999">
           </fieldset>
         </fieldset>
 

--- a/src/app/builder/builder.component.html
+++ b/src/app/builder/builder.component.html
@@ -65,9 +65,8 @@
             </select>
           </fieldset>
           <fieldset *ngIf="playPlaylist">
-            <p>Optionally play a single itunes:season of your podcast. Leave blank to include all episodes</p>
-            <input type="number" [(ngModel)]="props.playlistSeason"
-              placeholder="Season Number" min="1" max="999">
+            <p>Optionally filter to a single itunes:season of your podcast. Leave blank to include all episodes.</p>
+            <input type="number" [(ngModel)]="props.playlistSeason" placeholder="Season Number" min="1" max="999">
           </fieldset>
         </fieldset>
 

--- a/src/app/builder/builder.component.ts
+++ b/src/app/builder/builder.component.ts
@@ -23,6 +23,7 @@ export class BuilderComponent implements OnInit {
   editMode = false;
   playLatest = false;
   playPlaylist = false;
+  playSeason = false;
   feedError = false;
   sslError: string = null;
 
@@ -69,8 +70,10 @@ export class BuilderComponent implements OnInit {
     this.playPlaylist = !this.playPlaylist;
     if (this.playPlaylist) {
       this.props.playlistLength = this.props.playlistLength || 10;
+      this.props.playlistSeason = this.props.playlistSeason || null;
     } else {
       this.props.playlistLength = 0;
+      this.props.playlistSeason = null;
     }
     this.resetPreviewIframe();
   }

--- a/src/app/builder/builder.component.ts
+++ b/src/app/builder/builder.component.ts
@@ -70,9 +70,18 @@ export class BuilderComponent implements OnInit {
     this.playPlaylist = !this.playPlaylist;
     if (this.playPlaylist) {
       this.props.playlistLength = this.props.playlistLength || 10;
-      this.props.playlistSeason = this.props.playlistSeason || null;
     } else {
       this.props.playlistLength = 0;
+    }
+    this.resetPreviewIframe();
+  }
+
+  togglePlaySeason() {
+    this.playSeason = !this.playSeason;
+    if (this.playSeason) {
+      this.props.playlistSeason = this.props.playlistSeason || 1;
+      this.props.playlistLength = 'all';
+    } else {
       this.props.playlistSeason = null;
     }
     this.resetPreviewIframe();

--- a/src/app/builder/builder.properties.ts
+++ b/src/app/builder/builder.properties.ts
@@ -2,7 +2,8 @@ import { EMBED_FEED_URL_PARAM, EMBED_EPISODE_GUID_PARAM,
   EMBED_TITLE_PARAM, EMBED_SUBTITLE_PARAM, EMBED_CTA_TITLE_PARAM,
   EMBED_AUDIO_URL_PARAM, EMBED_IMAGE_URL_PARAM,
   EMBED_CTA_URL_PARAM, EMBED_SUBSCRIBE_URL_PARAM, EMBED_SUBSCRIBE_TARGET,
-  EMBED_SHOW_PLAYLIST_PARAM, EMBED_EP_IMAGE_URL_PARAM } from '../embed';
+  EMBED_SHOW_PLAYLIST_PARAM, EMBED_EP_IMAGE_URL_PARAM,
+  EMBED_PLAYLIST_SEASON_PARAM } from '../embed';
 
 export class BuilderProperties {
 
@@ -19,7 +20,8 @@ export class BuilderProperties {
       params[EMBED_CTA_URL_PARAM],
       params[EMBED_SUBSCRIBE_URL_PARAM],
       params[EMBED_SUBSCRIBE_TARGET],
-      params[EMBED_SHOW_PLAYLIST_PARAM]
+      params[EMBED_SHOW_PLAYLIST_PARAM],
+      params[EMBED_PLAYLIST_SEASON_PARAM]
     );
   }
 
@@ -40,7 +42,8 @@ export class BuilderProperties {
     public ctaUrl?: string,
     public subscribeUrl?: string,
     public subscribeTarget?: string,
-    public playlistLength?: number | string
+    public playlistLength?: number | string,
+    public playlistSeason?: number | string
   ) {}
 
   get allParams () {
@@ -56,7 +59,8 @@ export class BuilderProperties {
       ctaUrl: EMBED_CTA_URL_PARAM,
       subscribeUrl: EMBED_SUBSCRIBE_URL_PARAM,
       subscribeTarget: EMBED_SUBSCRIBE_TARGET,
-      playlistLength: EMBED_SHOW_PLAYLIST_PARAM
+      playlistLength: EMBED_SHOW_PLAYLIST_PARAM,
+      playlistSeason: EMBED_PLAYLIST_SEASON_PARAM
     };
   }
 

--- a/src/app/embed/embed.constants.ts
+++ b/src/app/embed/embed.constants.ts
@@ -15,3 +15,4 @@ export const EMBED_SUBSCRIBE_URL_PARAM      = 'us';
 export const EMBED_SUBSCRIBE_TARGET         = 'gs';
 export const EMBED_CTA_TARGET               = 'gc';
 export const EMBED_SHOW_PLAYLIST_PARAM      = 'sp';
+export const EMBED_PLAYLIST_SEASON_PARAM    = 'se';


### PR DESCRIPTION
For #187.

- [x] Feeds with an `<itunes:type>serial</itunes:type>` get their playlist episode order reversed.
  - NOTE 1: this means a playlist player (`?sp=10`) for these podcasts will now start with the _last / furthest-down_ episode instead of the top one.
  - NOTE 2: i made no attempt to actually order the RSS items by <pubDate> or <itunes:episode> or anything else.  As before, this player just pulls the episodes in the order they happen to occur in the RSS.  This is fine for our feeds, since Feeder always orders published_at desc.  But might do weird stuff for 3rd party feeds?
- [x] Add a `?se=` parameter.  Set it to the season number you want to filter to.
  - NOTE: most users will want to set `?sp=all&se=99`. Make sure the playlist has _all_ the episodes of the season, instead of limiting it.
- [x] Updated the build to include the season param

![image](https://user-images.githubusercontent.com/1410587/81232901-f5434a80-8fb2-11ea-9b27-472c4f7b48ea.png)
