### PR TITLE
Fix unenclosed items

### DIFF
--- a/src/app/builder/episode/episode-picker.component.ts
+++ b/src/app/builder/episode/episode-picker.component.ts
@@ -82,7 +82,11 @@ export class EpisodePickerComponent implements OnChanges, OnInit {
           return txt.value;
         }(item.querySelector('title').innerHTML);
 
-        let encUrl = item.querySelector('enclosure').getAttribute('url');
+        let encUrl = null;
+        let enc = item.querySelector('enclosure');
+        if (enc) {
+          encUrl = enc.getAttribute('url');
+        }
 
         let epImg = feedImg;
         let __img = Array.from(item.querySelectorAll('*[href]')).filter(e => e.nodeName === 'itunes:image')[0];

--- a/src/app/embed/adapters/feed.adapter.ts
+++ b/src/app/embed/adapters/feed.adapter.ts
@@ -132,7 +132,7 @@ export class FeedAdapter implements DataAdapter {
   processEpisode(item: Element, props: AdapterProperties = {}): AdapterProperties {
     props.title = this.getTagText(item, 'title');
     props.audioUrl = this.getTagTextNS(item, FEEDBURNER_NAMESPACE, 'origEnclosureLink')
-                  || this.getTagAttribute(item, 'enclosure', 'url');
+                  || this.getTagAttribute(item, 'enclosure', 'url') || null;
     props.artworkUrl = this.getTagAttributeNS(item, ITUNES_NAMESPACE, 'image', 'href');
     const duration = this.getTagTextNS(item, ITUNES_NAMESPACE, 'duration');
     props.duration = duration ? this.durationInSec(duration) : 0;

--- a/src/app/embed/share/share-modal.component.ts
+++ b/src/app/embed/share/share-modal.component.ts
@@ -5,7 +5,7 @@ import { Component, EventEmitter, Output, Input } from '@angular/core';
   styleUrls: ['share-modal.component.css'],
   template: `
     <button class="close-btn" (click)="closeModal()" (window:keydown)="handleKeypress($event)">✖</button>
-    <template [ngIf]="mode == 'share'">
+    <ng-template [ngIf]="mode == 'share'">
       <h1>Use this player on your site</h1>
       <p>You can embed this player on your own site by including the following <code>iframe</code> tag.</p>
 
@@ -16,15 +16,15 @@ import { Component, EventEmitter, Output, Input } from '@angular/core';
       </div>
 
       <a [href]="customizeHref" id="customize-btn" target="_blank">Customize this player</a>
-    </template>
-    <template [ngIf]="mode == 'cookie'">
+    </ng-template>
+    <ng-template [ngIf]="mode == 'cookie'">
       <h1>Cookie Policy</h1>
       <p>
         We use cookies to help improve our player. See our
         <a target="blank" href="https://exchange.prx.org/privacy-policy">Privacy Policy</a>
         for more details.
       </p>
-    </template>
+    </ng-template>
   `
 })
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,8 @@
 /*
  * Global styles manifest
  */
+@import url(https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans);
 body {
   margin: 0;
   border: 0;
@@ -8,5 +10,3 @@ body {
   font-family: Helvetica, sans-serif;
   font-size: 16px;
 }
-@import url(https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css);
-@import url(https://fonts.googleapis.com/css?family=Open+Sans);


### PR DESCRIPTION
Fixes #229 

- [x] Make the player work when items in the feed have no enclosure
- [x] Make the player render even if a specific item has no audio - the player won't play of course, but render title and such.